### PR TITLE
getopt refactor and org->owner consistency

### DIFF
--- a/include/ghcli/comments.h
+++ b/include/ghcli/comments.h
@@ -46,15 +46,25 @@ struct ghcli_comment {
 };
 
 struct ghcli_submit_comment_opts {
-    const char *org, *repo;
+    const char *owner, *repo;
     int         issue;
     sn_sv       message;
     bool        always_yes;
 };
 
-int  ghcli_get_comments(const char *url, ghcli_comment **comments);
-void ghcli_print_comment_list(FILE *stream, ghcli_comment *comments, size_t comments_size);
-void ghcli_issue_comments(FILE *stream, const char *org, const char *repo, int issue);
-void ghcli_comment_submit(ghcli_submit_comment_opts opts);
+int  ghcli_get_comments(
+    const char *url,
+    ghcli_comment **comments);
+void ghcli_print_comment_list(
+    FILE *stream,
+    ghcli_comment *comments,
+    size_t comments_size);
+void ghcli_issue_comments(
+    FILE *stream,
+    const char *owner,
+    const char *repo,
+    int issue);
+void ghcli_comment_submit(
+    ghcli_submit_comment_opts opts);
 
 #endif /* COMMENTS_H */

--- a/include/ghcli/forks.h
+++ b/include/ghcli/forks.h
@@ -41,9 +41,9 @@ struct ghcli_fork {
     int   forks;
 };
 
-int  ghcli_get_forks(const char *org, const char *reponame, ghcli_fork **out);
-void ghcli_fork_create(const char *org, const char *repo, const char *in);
+int  ghcli_get_forks(const char *owner, const char *reponame, ghcli_fork **out);
+void ghcli_fork_create(const char *owner, const char *repo, const char *in);
 void ghcli_print_forks(FILE *stream, ghcli_fork *forks, size_t forks_size);
-void ghcli_fork_delete(const char *org, const char *repo);
+void ghcli_fork_delete(const char *owner, const char *repo);
 
 #endif /* FORK_H */

--- a/include/ghcli/gitconfig.h
+++ b/include/ghcli/gitconfig.h
@@ -32,7 +32,7 @@
 
 #include <sn/sn.h>
 
-void  ghcli_gitconfig_get_repo(const char **org, const char **repo);
+void  ghcli_gitconfig_get_repo(const char **owner, const char **repo);
 sn_sv ghcli_gitconfig_get_current_branch(void);
 
 #endif /* GITCONFIG_H */

--- a/include/ghcli/issues.h
+++ b/include/ghcli/issues.h
@@ -66,12 +66,31 @@ struct ghcli_submit_issue_options {
 };
 
 
-int  ghcli_get_issues(const char *org, const char *reponame, bool all, ghcli_issue **out);
-void ghcli_issues_free(ghcli_issue *it, int size);
-void ghcli_print_issues_table(FILE *stream, ghcli_issue *issues, int issues_size);
-void ghcli_issue_summary(FILE *stream, const char *org, const char *reponame, int issue_number);
-void ghcli_issue_close(const char *org, const char *repo, int issue_number);
-void ghcli_issue_reopen(const char *org, const char *repo, int issue_number);
+int  ghcli_get_issues(
+    const char *owner,
+    const char *reponame,
+    bool all,
+    ghcli_issue **out);
+void ghcli_issues_free(
+    ghcli_issue *it,
+    int size);
+void ghcli_print_issues_table(
+    FILE *stream,
+    ghcli_issue *issues,
+    int issues_size);
+void ghcli_issue_summary(
+    FILE *stream,
+    const char *owner,
+    const char *reponame,
+    int issue_number);
+void ghcli_issue_close(
+    const char *owner,
+    const char *repo,
+    int issue_number);
+void ghcli_issue_reopen(
+    const char *owner,
+    const char *repo,
+    int issue_number);
 void ghcli_issue_submit(ghcli_submit_issue_options);
 
 #endif /* ISSUES_H */

--- a/include/ghcli/pulls.h
+++ b/include/ghcli/pulls.h
@@ -69,15 +69,15 @@ struct ghcli_submit_pull_options {
     bool  always_yes;
 };
 
-int  ghcli_get_prs(const char *org, const char *reponame, bool all, ghcli_pull **out);
+int  ghcli_get_prs(const char *owner, const char *reponame, bool all, ghcli_pull **out);
 void ghcli_pulls_free(ghcli_pull *it, int n);
 void ghcli_pulls_summary_free(ghcli_pull_summary *it);
 void ghcli_print_pr_table(FILE *stream, ghcli_pull *pulls, int pulls_size);
-void ghcli_print_pr_diff(FILE *stream, const char *org, const char *reponame, int pr_number);
-void ghcli_pr_summary(FILE *stream, const char *org, const char *reponame, int pr_number);
+void ghcli_print_pr_diff(FILE *stream, const char *owner, const char *reponame, int pr_number);
+void ghcli_pr_summary(FILE *stream, const char *owner, const char *reponame, int pr_number);
 void ghcli_pr_submit(ghcli_submit_pull_options);
-void ghcli_pr_merge(FILE *stream, const char *org, const char *reponame, int pr_number);
-void ghcli_pr_close(const char *org, const char *reponame, int pr_number);
-void ghcli_pr_reopen(const char *org, const char *reponame, int pr_number);
+void ghcli_pr_merge(FILE *stream, const char *owner, const char *reponame, int pr_number);
+void ghcli_pr_close(const char *owner, const char *reponame, int pr_number);
+void ghcli_pr_reopen(const char *owner, const char *reponame, int pr_number);
 
 #endif /* PULLS_H */

--- a/include/ghcli/repos.h
+++ b/include/ghcli/repos.h
@@ -43,10 +43,10 @@ struct ghcli_repo {
     bool  is_fork;
 };
 
-int  ghcli_get_repos(const char *org, ghcli_repo **out);
+int  ghcli_get_repos(const char *owner, ghcli_repo **out);
 int  ghcli_get_own_repos(ghcli_repo **out);
 void ghcli_repos_free(ghcli_repo *, size_t);
 void ghcli_print_repos_table(FILE *, ghcli_repo *, size_t);
-void ghcli_repo_delete(const char *org, const char *repo);
+void ghcli_repo_delete(const char *owner, const char *repo);
 
 #endif /* REPOS_H */

--- a/include/ghcli/review.h
+++ b/include/ghcli/review.h
@@ -53,11 +53,30 @@ struct ghcli_pr_review_comment {
     int   original_position;
 };
 
-void   ghcli_review_reviews_free(ghcli_pr_review *it, size_t size);
-void   ghcli_review_comments_free(ghcli_pr_review_comment *it, size_t size);
-size_t ghcli_review_get_reviews(const char *org, const char *repo, int pr, ghcli_pr_review **out);
-size_t ghcli_review_get_review_comments(const char *org, const char *repo, int pr, int review_id, ghcli_pr_review_comment **out);
-void   ghcli_review_print_review_table(FILE *, ghcli_pr_review *, size_t);
-void   ghcli_review_print_comments(FILE *out, ghcli_pr_review_comment *comments, size_t comments_size);
+void ghcli_review_reviews_free(
+    ghcli_pr_review *it,
+    size_t size);
+void ghcli_review_comments_free(
+    ghcli_pr_review_comment *it,
+    size_t size);
+size_t ghcli_review_get_reviews(
+    const char *owner,
+    const char *repo,
+    int pr,
+    ghcli_pr_review **out);
+size_t ghcli_review_get_review_comments(
+    const char *owner,
+    const char *repo,
+    int pr,
+    int review_id,
+    ghcli_pr_review_comment **out);
+void ghcli_review_print_review_table(
+    FILE *,
+    ghcli_pr_review *,
+    size_t);
+void ghcli_review_print_comments(
+    FILE *out,
+    ghcli_pr_review_comment *comments,
+    size_t comments_size);
 
 #endif /* REVIEW_H */

--- a/src/comments.c
+++ b/src/comments.c
@@ -125,11 +125,11 @@ ghcli_print_comment_list(
 }
 
 void
-ghcli_issue_comments(FILE *stream, const char *org, const char *repo, int issue)
+ghcli_issue_comments(FILE *stream, const char *owner, const char *repo, int issue)
 {
     const char    *url      = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues/%d/comments",
-        org, repo, issue);
+        owner, repo, issue);
     ghcli_comment *comments = NULL;
     int            n        = ghcli_get_comments(url, &comments);
     ghcli_print_comment_list(stream, comments, (size_t)n);
@@ -152,7 +152,7 @@ comment_init(FILE *f, void *_data)
         "# All lines with a leading '#' are discarded and will not\n"
         "# appear in your comment.\n"
         "# COMMENT IN : %s/%s #%d\n",
-        info->org, info->repo, info->issue);
+        info->owner, info->repo, info->issue);
 }
 
 static sn_sv
@@ -171,7 +171,7 @@ ghcli_comment_submit(ghcli_submit_comment_opts opts)
     fprintf(
         stdout,
         "You will be commenting the following in %s/%s #%d:\n"SV_FMT"\n",
-        opts.org, opts.repo, opts.issue, SV_ARGS(message));
+        opts.owner, opts.repo, opts.issue, SV_ARGS(message));
 
     if (!opts.always_yes) {
         if (!sn_yesno("Is this okay?"))

--- a/src/curl.c
+++ b/src/curl.c
@@ -364,7 +364,7 @@ ghcli_perform_submit_comment(
         SV_ARGS(opts.message));
     char *url         = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues/%d/comments",
-        opts.org, opts.repo, opts.issue);
+        opts.owner, opts.repo, opts.issue);
 
     ghcli_fetch_with_method("POST", url, post_fields, out);
     free(post_fields);

--- a/src/forks.c
+++ b/src/forks.c
@@ -77,7 +77,7 @@ parse_fork(struct json_stream *input, ghcli_fork *out)
 }
 
 int
-ghcli_get_forks(const char *org, const char *reponame, ghcli_fork **out)
+ghcli_get_forks(const char *owner, const char *reponame, ghcli_fork **out)
 {
     ghcli_fetch_buffer  buffer = {0};
     char               *url    = NULL;
@@ -89,7 +89,7 @@ ghcli_get_forks(const char *org, const char *reponame, ghcli_fork **out)
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/forks",
-        org, reponame);
+        owner, reponame);
     ghcli_fetch(url, &buffer);
 
     free(url);
@@ -137,14 +137,14 @@ ghcli_print_forks(FILE *stream, ghcli_fork *forks, size_t forks_size)
 }
 
 void
-ghcli_fork_create(const char *org, const char *repo, const char *_in)
+ghcli_fork_create(const char *owner, const char *repo, const char *_in)
 {
     char               *url       = NULL;
     char               *post_data = NULL;
     sn_sv               in        = SV_NULL;
     ghcli_fetch_buffer  buffer    = {0};
 
-    url = sn_asprintf("https://api.github.com/repos/%s/%s/forks", org, repo);
+    url = sn_asprintf("https://api.github.com/repos/%s/%s/forks", owner, repo);
     if (_in) {
         in        = ghcli_json_escape(SV((char *)_in));
         post_data = sn_asprintf("{\"organization\":\""SV_FMT"\"}",

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -338,8 +338,28 @@ subcommand_pulls(int argc, char *argv[])
         return subcommand_pull_create(argc, argv);
     }
 
+    const struct option options[] = {
+        { .name    = "all",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'a' },
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "pull",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'p' },
+        {0},
+    };
+
     /* Parse commandline options */
-    while ((ch = getopt(argc, argv, "o:r:p:a")) != -1) {
+    while ((ch = getopt_long(argc, argv, "o:r:p:a", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -427,8 +447,28 @@ subcommand_issues(int argc, char *argv[])
         return subcommand_issue_create(argc, argv);
     }
 
+    const struct option options[] = {
+        { .name    = "all",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'a' },
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "issue",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'i' },
+        {0},
+    };
+
     /* parse options */
-    while ((ch = getopt(argc, argv, "o:r:i:a")) != -1) {
+    while ((ch = getopt_long(argc, argv, "o:r:i:a", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -500,8 +540,28 @@ subcommand_review(int argc, char *argv[])
     const char *owner     = NULL;
     const char *repo      = NULL;
 
+    const struct option options[] = {
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "pull",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'p' },
+        { .name    = "comment",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'c' },
+        {0},
+    };
+
     /* parse options */
-    while ((ch = getopt(argc, argv, "p:o:r:c:")) != -1) {
+    while ((ch = getopt_long(argc, argv, "p:o:r:c:", options, NULL)) != -1) {
         switch (ch) {
         case 'p': {
             char *endptr = NULL;
@@ -566,7 +626,24 @@ subcommand_forks_create(int argc, char *argv[])
 {
     int ch;
     const char *owner = NULL, *repo = NULL, *in = NULL;
-    while ((ch = getopt(argc, argv, "o:r:i:")) != -1) {
+
+    const struct option options[] = {
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "into",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'i' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "o:r:i:", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -621,7 +698,23 @@ subcommand_repos(int argc, char *argv[])
     ghcli_repo *repos      = NULL;
     bool        always_yes = false;
 
-    while ((ch = getopt(argc, argv, "o:r:y")) != -1) {
+    const struct option options[] = {
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "yes",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'y' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "o:r:y", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -710,7 +803,19 @@ subcommand_gist_create(int argc, char *argv[])
     ghcli_new_gist  opts = {0};
     const char     *file = NULL;
 
-    while ((ch = getopt(argc, argv, "f:d:")) != -1) {
+    const struct option options[] = {
+        { .name    = "file",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "description",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "f:d:", options, NULL)) != -1) {
         switch (ch) {
         case 'f':
             file = optarg;
@@ -754,7 +859,15 @@ subcommand_gist_delete(int argc, char *argv[])
     bool        always_yes = false;
     const char *gist_id    = NULL;
 
-    while ((ch = getopt(argc, argv, "y")) != -1) {
+    const struct option options[] = {
+        { .name    = "yes",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'y' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "y", options, NULL)) != -1) {
         switch (ch) {
         case 'y':
             always_yes = true;
@@ -799,7 +912,15 @@ subcommand_gists(int argc, char *argv[])
         }
     }
 
-    while ((ch = getopt(argc, argv, "u:")) != -1) {
+    const struct option options[] = {
+        { .name    = "user",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'u' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "u:", options, NULL)) != -1) {
         switch (ch) {
         case 'u':
             user = optarg;
@@ -833,7 +954,23 @@ subcommand_forks(int argc, char *argv[])
         return subcommand_forks_create(argc, argv);
     }
 
-    while ((ch = getopt(argc, argv, "o:r:y")) != -1) {
+    const struct option options[] = {
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
+        { .name    = "owner",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'o' },
+        { .name    = "yes",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'y' },
+        {0},
+    };
+
+    while ((ch = getopt_long(argc, argv, "o:r:y", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;

--- a/src/issues.c
+++ b/src/issues.c
@@ -85,7 +85,7 @@ ghcli_issues_free(ghcli_issue *it, int size)
 
 int
 ghcli_get_issues(
-    const char *org,
+    const char *owner,
     const char *reponame,
     bool all,
     ghcli_issue **out)
@@ -97,7 +97,7 @@ ghcli_get_issues(
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues?per_page=100&state=%s",
-        org, reponame,
+        owner, reponame,
         all ? "all" : "open");
     ghcli_fetch(url, &json_buffer);
 
@@ -255,7 +255,7 @@ ghcli_issue_details_free(ghcli_issue_details *it)
 void
 ghcli_issue_summary(
     FILE *stream,
-    const char *org,
+    const char *owner,
     const char *repo,
     int issue_number)
 {
@@ -266,7 +266,7 @@ ghcli_issue_summary(
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues/%d?per_page=100",
-        org, repo,
+        owner, repo,
         issue_number);
     ghcli_fetch(url, &buffer);
 
@@ -284,7 +284,7 @@ ghcli_issue_summary(
 }
 
 void
-ghcli_issue_close(const char *org, const char *repo, int issue_number)
+ghcli_issue_close(const char *owner, const char *repo, int issue_number)
 {
     ghcli_fetch_buffer  json_buffer = {0};
     const char         *url         = NULL;
@@ -292,7 +292,7 @@ ghcli_issue_close(const char *org, const char *repo, int issue_number)
 
     url  = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues/%d",
-        org, repo,
+        owner, repo,
         issue_number);
     data = sn_asprintf("{ \"state\": \"close\"}");
 
@@ -304,7 +304,7 @@ ghcli_issue_close(const char *org, const char *repo, int issue_number)
 }
 
 void
-ghcli_issue_reopen(const char *org, const char *repo, int issue_number)
+ghcli_issue_reopen(const char *owner, const char *repo, int issue_number)
 {
     ghcli_fetch_buffer  json_buffer = {0};
     const char         *url         = NULL;
@@ -312,7 +312,7 @@ ghcli_issue_reopen(const char *org, const char *repo, int issue_number)
 
     url  = sn_asprintf(
         "https://api.github.com/repos/%s/%s/issues/%d",
-        org, repo,
+        owner, repo,
         issue_number);
     data = sn_asprintf("{ \"state\": \"open\"}");
 

--- a/src/pulls.c
+++ b/src/pulls.c
@@ -95,7 +95,7 @@ ghcli_pulls_free(ghcli_pull *it, int n)
 }
 
 int
-ghcli_get_prs(const char *org, const char *reponame, bool all, ghcli_pull **out)
+ghcli_get_prs(const char *owner, const char *reponame, bool all, ghcli_pull **out)
 {
     int                 count       = 0;
     json_stream         stream      = {0};
@@ -104,7 +104,7 @@ ghcli_get_prs(const char *org, const char *reponame, bool all, ghcli_pull **out)
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls?per_page=100&state=%s",
-        org, reponame, all ? "all" : "open");
+        owner, reponame, all ? "all" : "open");
     ghcli_fetch(url, &json_buffer);
 
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
@@ -163,14 +163,14 @@ ghcli_print_pr_table(FILE *stream, ghcli_pull *pulls, int pulls_size)
 void
 ghcli_print_pr_diff(
     FILE *stream,
-    const char *org,
+    const char *owner,
     const char *reponame,
     int pr_number)
 {
     char *url = NULL;
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     ghcli_curl(stream, url, "Accept: application/vnd.github.v3.diff");
     free(url);
 }
@@ -500,7 +500,7 @@ ghcli_pulls_summary_free(ghcli_pull_summary *it)
 void
 ghcli_pr_summary(
     FILE *out,
-    const char *org,
+    const char *owner,
     const char *reponame,
     int pr_number)
 {
@@ -514,7 +514,7 @@ ghcli_pr_summary(
     /* General info */
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     ghcli_fetch(url, &json_buffer);
 
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
@@ -529,7 +529,7 @@ ghcli_pr_summary(
     /* Commits */
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/commits",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     commits_size = ghcli_get_pull_commits(url, &commits);
 
     ghcli_print_pr_summary(out, &result);
@@ -597,7 +597,7 @@ ghcli_pr_submit(ghcli_submit_pull_options opts)
 }
 
 void
-ghcli_pr_merge(FILE *out, const char *org, const char *reponame, int pr_number)
+ghcli_pr_merge(FILE *out, const char *owner, const char *reponame, int pr_number)
 {
     json_stream         stream      = {0};
     ghcli_fetch_buffer  json_buffer = {0};
@@ -610,7 +610,7 @@ ghcli_pr_merge(FILE *out, const char *org, const char *reponame, int pr_number)
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/merge",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     ghcli_fetch_with_method("PUT", url, data, &json_buffer);
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
@@ -639,7 +639,7 @@ ghcli_pr_merge(FILE *out, const char *org, const char *reponame, int pr_number)
 }
 
 void
-ghcli_pr_close(const char *org, const char *reponame, int pr_number)
+ghcli_pr_close(const char *owner, const char *reponame, int pr_number)
 {
     ghcli_fetch_buffer  json_buffer = {0};
     const char         *url         = NULL;
@@ -647,7 +647,7 @@ ghcli_pr_close(const char *org, const char *reponame, int pr_number)
 
     url  = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     data = sn_asprintf("{ \"state\": \"closed\"}");
 
     ghcli_fetch_with_method("PATCH", url, data, &json_buffer);
@@ -658,7 +658,7 @@ ghcli_pr_close(const char *org, const char *reponame, int pr_number)
 }
 
 void
-ghcli_pr_reopen(const char *org, const char *reponame, int pr_number)
+ghcli_pr_reopen(const char *owner, const char *reponame, int pr_number)
 {
     ghcli_fetch_buffer  json_buffer = {0};
     const char         *url         = NULL;
@@ -666,7 +666,7 @@ ghcli_pr_reopen(const char *org, const char *reponame, int pr_number)
 
     url  = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d",
-        org, reponame, pr_number);
+        owner, reponame, pr_number);
     data = sn_asprintf("{ \"state\": \"open\"}");
 
     ghcli_fetch_with_method("PATCH", url, data, &json_buffer);

--- a/src/repos.c
+++ b/src/repos.c
@@ -80,7 +80,7 @@ parse_repo(json_stream *input, ghcli_repo *out)
 }
 
 int
-ghcli_get_repos(const char *org, ghcli_repo **out)
+ghcli_get_repos(const char *owner, ghcli_repo **out)
 {
     char               *url    = NULL;
     ghcli_fetch_buffer  buffer = {0};
@@ -91,15 +91,15 @@ ghcli_get_repos(const char *org, ghcli_repo **out)
     /* Github is a little stupid in that it distinguishes
      * organizations and users. Thus, we have to find out, whether the
      * <org> param is a user or an actual organization. */
-    url = sn_asprintf("https://api.github.com/users/%s", org);
+    url = sn_asprintf("https://api.github.com/users/%s", owner);
     if (ghcli_curl_test_success(url)) {
         /* it is a user */
         free(url);
-        url = sn_asprintf("https://api.github.com/users/%s/repos", org);
+        url = sn_asprintf("https://api.github.com/users/%s/repos", owner);
     } else {
         /* this is an actual organization */
         free(url);
-        url = sn_asprintf("https://api.github.com/orgs/%s/repos", org);
+        url = sn_asprintf("https://api.github.com/orgs/%s/repos", owner);
     }
 
     ghcli_fetch(url, &buffer);
@@ -165,13 +165,13 @@ ghcli_repos_free(ghcli_repo *repos, size_t repos_size)
 }
 
 void
-ghcli_repo_delete(const char *org, const char *repo)
+ghcli_repo_delete(const char *owner, const char *repo)
 {
     char               *url    = NULL;
     ghcli_fetch_buffer  buffer = {0};
 
     url = sn_asprintf("https://api.github.com/repos/%s/%s",
-                      org, repo);
+                      owner, repo);
 
     ghcli_fetch_with_method("DELETE", url, NULL, &buffer);
 

--- a/src/review.c
+++ b/src/review.c
@@ -76,7 +76,7 @@ parse_review_header(json_stream *stream, ghcli_pr_review *it)
 
 size_t
 ghcli_review_get_reviews(
-    const char *org,
+    const char *owner,
     const char *repo,
     int pr,
     ghcli_pr_review **out)
@@ -89,7 +89,7 @@ ghcli_review_get_reviews(
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/reviews",
-        org, repo, pr);
+        owner, repo, pr);
     ghcli_fetch(url, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
@@ -229,7 +229,7 @@ ghcli_review_comments_free(ghcli_pr_review_comment *it, size_t size)
 
 size_t
 ghcli_review_get_review_comments(
-    const char               *org,
+    const char               *owner,
     const char               *repo,
     int                       pr,
     int                       review_id,
@@ -243,7 +243,7 @@ ghcli_review_get_review_comments(
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/reviews/%d/comments",
-        org, repo, pr, review_id);
+        owner, repo, pr, review_id);
     ghcli_fetch(url, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);

--- a/todo.org
+++ b/todo.org
@@ -47,6 +47,7 @@
    - [X] choose a git tag
    - [ ] attach files to release (aka assets)
    - [X] mark as prerelease or draft
+** TODO pulls commit table header is weird
 
 * On the review API
   - A PR has got reviews (could be none, could be a thousand)


### PR DESCRIPTION
This PR adds support for long options everywhere and makes the options behave consistently. --org has been replaced by --owner, as that is the more correct version for what this flag is doing.
Fixes #27
Fixes #28
