### PR TITLE
(#36) add support for paged results

### DIFF
--- a/docs/ghcli-forks.1
+++ b/docs/ghcli-forks.1
@@ -6,6 +6,7 @@
 .Nd Manage GitHub repositories forks
 .Sh SYNOPSIS
 .Nm
+.Op Fl n Ar n
 .Op Fl y
 .Op Fl o Ar owner Fl r Ar repo
 .Ar actions...
@@ -32,6 +33,14 @@ Do not ask for confirmation. Assume yes.
 .It Fl i , -into Ar target-owner
 When forking a repository, this is the organization or user the
 repository is forked into.
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+forks. Setting
+.Ar n
+to -1 will fetch all forks. Default: 30. Note that on repositories
+with many forks fetching all forks can take a considerable amount of
+time and may result in rate limiting by the GitHub API.
 .El
 .El
 .Sh ACTIONS

--- a/docs/ghcli-gists.1
+++ b/docs/ghcli-gists.1
@@ -6,6 +6,7 @@
 .Nd manage Github Gists
 .Sh SYNOPSIS
 .Nm
+.Op Fl n Ar n
 .Op Fl u Ar user
 .Nm
 .Cm create
@@ -31,6 +32,14 @@ will list Gists of the given or autodetected user account.
 .Bl -tag -width indent
 .It Fl u , -user Ar owner
 List Gists of the given user.
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+gists. Setting
+.Ar n
+to -1 will fetch all gists. Default: 30. Note that on users with many
+gists fetching all gists can take a considerable amount of time and
+may result in rate limiting by the GitHub API.
 .El
 .Sh SUBCOMMANDS
 .Bl -tag -width indent

--- a/docs/ghcli-issues.1
+++ b/docs/ghcli-issues.1
@@ -6,6 +6,7 @@
 .Nd Manage GitHub issues
 .Sh SYNOPSIS
 .Nm
+.Op Fl n Ar n
 .Op Fl a
 .Op Fl o Ar owner Fl r Ar repo
 .Op Ar actions...
@@ -32,7 +33,17 @@ combination with
 .Fl r .
 .It Fl a
 List all issues, including closed ones. Cannot be combined with
-actions.
+actions. This does not affect the
+.Fl n
+option.
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+issues. Setting
+.Ar n
+to -1 will fetch all issues. Default: 30. Note that
+on large repositories fetching all issues can take a considerable
+amount of time and may result in rate limiting by the GitHub API.
 .El
 
 .Sh SUBCOMMANDS

--- a/docs/ghcli-pulls.1
+++ b/docs/ghcli-pulls.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl a
+.Op Fl n Ar n
 .Op Fl o Ar owner Fl r Ar repo
 .Op Ar actions...
 .Nm
@@ -32,7 +33,17 @@ combination with
 .Fl r .
 .It Fl a
 List all PRs, including closed and merged ones. Cannot be combined
-with actions.
+with actions. This does not affect the
+.Fl n
+option.
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+pull requests. Default: 30. If
+.Ar n
+is set to -1 this will fetch all pull requests. Note that on large
+repositories fetching all pull requests can take a considerable amount
+of time and may result in rate limiting by the GitHub API.
 .El
 
 .Sh SUBCOMMANDS

--- a/docs/ghcli-releases.1
+++ b/docs/ghcli-releases.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 
 .Nm
+.Op Fl n Ar n
 .Op Fl o Ar owner Fl r Ar repo
 
 .Nm
@@ -47,7 +48,14 @@ used in combination with
 List releases in the given repo. This option can only be used in
 combination with
 .Fl r .
-
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+releases. Setting
+.Ar n
+to -1 will fetch all releases. Default: 30. Note that on repositories
+with many releases fetching all releases can take a considerable
+amount of time and may result in rate limiting by the GitHub API.
 .El
 
 .Sh SUBCOMMANDS

--- a/docs/ghcli-repos.1
+++ b/docs/ghcli-repos.1
@@ -6,6 +6,7 @@
 .Nd Manage GitHub repositories
 .Sh SYNOPSIS
 .Nm
+.Op Fl n Ar n
 .Op Fl o Ar owner
 .Nm
 .Op Fl y
@@ -31,9 +32,17 @@ used in combination with
 .It Fl r , -repo Ar repo
 Operate on the given repository. This option can only be used in
 combination with
-.Fl r o
+.Fl o .
 .It Fl y , -yes
 Do not ask for confirmation. Assume yes.
+.It Fl n , -count Ar n
+Fetch at least
+.Ar n
+repositories. Setting
+.Ar n
+to -1 will fetch all repositories. Default: 30. Note that on owners
+with many repositories fetching all of them can take a considerable
+amount of time and may result in rate limiting by the GitHub API.
 .El
 .El
 .Sh ACTIONS

--- a/docs/ghcli.1
+++ b/docs/ghcli.1
@@ -70,6 +70,15 @@ Print version and exit.
 .Sh OPTIONS
 Common options across almost all of the subcommands are:
 .Bl -tag -width indent
+.It Fl n , -count Ar n
+Fetch multiple pages of data. The default is usually 30 items, but
+this parameter allows to fetch more than that. Setting
+.Ar n
+to -1 will result in all pages being queried and all items being read.
+However, be careful with that, since if there is a lot of data to be
+fetched, it may result in rate limiting by the Github API, aside from
+the fact that it may also take a considerable amount of time to
+process.
 .It Fl a , -all
 Fetch all data, including closed issues and closed/merged PRs.
 .It Fl y , -yes

--- a/include/ghcli/curl.h
+++ b/include/ghcli/curl.h
@@ -42,16 +42,18 @@ struct ghcli_fetch_buffer {
 };
 
 void ghcli_fetch(
-    const char *url,
-    ghcli_fetch_buffer *out);
+    const char          *url,
+    char               **pagination_next,
+    ghcli_fetch_buffer  *out);
 void ghcli_curl(
     FILE *stream,
     const char *url,
     const char *content_type);
 void ghcli_fetch_with_method(
-    const char *method,
-    const char *url,
-    const char *data,
+    const char  *method,
+    const char  *url,
+    const char  *data,
+    char       **pagination_next,
     ghcli_fetch_buffer *out);
 void ghcli_post_upload(
     const char         *url,

--- a/include/ghcli/forks.h
+++ b/include/ghcli/forks.h
@@ -41,9 +41,21 @@ struct ghcli_fork {
     int   forks;
 };
 
-int  ghcli_get_forks(const char *owner, const char *reponame, ghcli_fork **out);
-void ghcli_fork_create(const char *owner, const char *repo, const char *in);
-void ghcli_print_forks(FILE *stream, ghcli_fork *forks, size_t forks_size);
-void ghcli_fork_delete(const char *owner, const char *repo);
+int ghcli_get_forks(
+    const char  *owner,
+    const char  *reponame,
+    int          max,
+    ghcli_fork **out);
+void ghcli_fork_create(
+    const char *owner,
+    const char *repo,
+    const char *in);
+void ghcli_print_forks(
+    FILE       *stream,
+    ghcli_fork *forks,
+    size_t      forks_size);
+void ghcli_fork_delete(
+    const char *owner,
+    const char *repo);
 
 #endif /* FORK_H */

--- a/include/ghcli/gists.h
+++ b/include/ghcli/gists.h
@@ -61,13 +61,20 @@ struct ghcli_new_gist {
     const char *gist_description;
 };
 
-int         ghcli_get_gists(const char *user, ghcli_gist **out);
-ghcli_gist *ghcli_get_gist(const char *gist_id);
-void        ghcli_print_gists_table(
+int ghcli_get_gists(
+    const char *user,
+    int max,
+    ghcli_gist **out);
+ghcli_gist *ghcli_get_gist(
+    const char *gist_id);
+void ghcli_print_gists_table(
     FILE *stream,
     ghcli_gist *gists,
     int gists_size);
-void        ghcli_create_gist(ghcli_new_gist);
-void        ghcli_delete_gist(const char *gist_id, bool always_yes);
+void ghcli_create_gist(
+    ghcli_new_gist);
+void ghcli_delete_gist(
+    const char *gist_id,
+    bool always_yes);
 
 #endif /* GISTS_H */

--- a/include/ghcli/issues.h
+++ b/include/ghcli/issues.h
@@ -70,6 +70,7 @@ int  ghcli_get_issues(
     const char *owner,
     const char *reponame,
     bool all,
+    int max,
     ghcli_issue **out);
 void ghcli_issues_free(
     ghcli_issue *it,

--- a/include/ghcli/pulls.h
+++ b/include/ghcli/pulls.h
@@ -69,15 +69,45 @@ struct ghcli_submit_pull_options {
     bool  always_yes;
 };
 
-int  ghcli_get_prs(const char *owner, const char *reponame, bool all, ghcli_pull **out);
-void ghcli_pulls_free(ghcli_pull *it, int n);
-void ghcli_pulls_summary_free(ghcli_pull_summary *it);
-void ghcli_print_pr_table(FILE *stream, ghcli_pull *pulls, int pulls_size);
-void ghcli_print_pr_diff(FILE *stream, const char *owner, const char *reponame, int pr_number);
-void ghcli_pr_summary(FILE *stream, const char *owner, const char *reponame, int pr_number);
-void ghcli_pr_submit(ghcli_submit_pull_options);
-void ghcli_pr_merge(FILE *stream, const char *owner, const char *reponame, int pr_number);
-void ghcli_pr_close(const char *owner, const char *reponame, int pr_number);
-void ghcli_pr_reopen(const char *owner, const char *reponame, int pr_number);
+int ghcli_get_prs(
+    const char  *owner,
+    const char  *reponame,
+    bool         all,
+    int          max,
+    ghcli_pull **out);
+void ghcli_pulls_free(
+    ghcli_pull *it,
+    int         n);
+void ghcli_pulls_summary_free(
+    ghcli_pull_summary *it);
+void ghcli_print_pr_table(
+    FILE       *stream,
+    ghcli_pull *pulls,
+    int         pulls_size);
+void ghcli_print_pr_diff(
+    FILE       *stream,
+    const char *owner,
+    const char *reponame,
+    int         pr_number);
+void ghcli_pr_summary(
+    FILE       *stream,
+    const char *owner,
+    const char *reponame,
+    int         pr_number);
+void ghcli_pr_submit(
+    ghcli_submit_pull_options);
+void ghcli_pr_merge(
+    FILE       *stream,
+    const char *owner,
+    const char *reponame,
+    int         pr_number);
+void ghcli_pr_close(
+    const char *owner,
+    const char *reponame,
+    int         pr_number);
+void ghcli_pr_reopen(
+    const char *owner,
+    const char *reponame,
+    int         pr_number);
 
 #endif /* PULLS_H */

--- a/include/ghcli/releases.h
+++ b/include/ghcli/releases.h
@@ -72,11 +72,23 @@ struct ghcli_new_release {
 int ghcli_get_releases(
     const char     *owner,
     const char     *repo,
+    int             max,
     ghcli_release **out);
-void ghcli_print_releases(FILE *, ghcli_release *, int);
-void ghcli_free_releases(ghcli_release *, int);
-void ghcli_create_release(const ghcli_new_release *);
-void ghcli_release_push_asset(ghcli_new_release *, ghcli_release_asset);
-void ghcli_delete_release(const char *owner, const char *repo, const char *id);
+void ghcli_print_releases(
+    FILE *,
+    ghcli_release *,
+    int);
+void ghcli_free_releases(
+    ghcli_release *,
+    int);
+void ghcli_create_release(
+    const ghcli_new_release *);
+void ghcli_release_push_asset(
+    ghcli_new_release *,
+    ghcli_release_asset);
+void ghcli_delete_release(
+    const char *owner,
+    const char *repo,
+    const char *id);
 
 #endif /* RELEASES_H */

--- a/include/ghcli/repos.h
+++ b/include/ghcli/repos.h
@@ -43,7 +43,7 @@ struct ghcli_repo {
     bool  is_fork;
 };
 
-int  ghcli_get_repos(const char *owner, ghcli_repo **out);
+int  ghcli_get_repos(const char *owner, int max, ghcli_repo **out);
 int  ghcli_get_own_repos(ghcli_repo **out);
 void ghcli_repos_free(ghcli_repo *, size_t);
 void ghcli_print_repos_table(FILE *, ghcli_repo *, size_t);

--- a/include/ghcli/repos.h
+++ b/include/ghcli/repos.h
@@ -44,7 +44,7 @@ struct ghcli_repo {
 };
 
 int  ghcli_get_repos(const char *owner, int max, ghcli_repo **out);
-int  ghcli_get_own_repos(ghcli_repo **out);
+int  ghcli_get_own_repos(int max, ghcli_repo **out);
 void ghcli_repos_free(ghcli_repo *, size_t);
 void ghcli_print_repos_table(FILE *, ghcli_repo *, size_t);
 void ghcli_repo_delete(const char *owner, const char *repo);

--- a/src/comments.c
+++ b/src/comments.c
@@ -50,7 +50,7 @@ perform_submit_comment(
         "https://api.github.com/repos/%s/%s/issues/%d/comments",
         opts.owner, opts.repo, opts.issue);
 
-    ghcli_fetch_with_method("POST", url, post_fields, out);
+    ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
     free(post_fields);
     free(url);
 }
@@ -97,7 +97,7 @@ ghcli_get_comments(const char *url, ghcli_comment **comments)
     json_stream        stream      = {0};
     ghcli_fetch_buffer json_buffer = {0};
 
-    ghcli_fetch(url, &json_buffer);
+    ghcli_fetch(url, NULL, &json_buffer);
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
 

--- a/src/forks.c
+++ b/src/forks.c
@@ -90,7 +90,7 @@ ghcli_get_forks(const char *owner, const char *reponame, ghcli_fork **out)
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/forks",
         owner, reponame);
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     free(url);
 
@@ -151,7 +151,7 @@ ghcli_fork_create(const char *owner, const char *repo, const char *_in)
                                 SV_ARGS(in));
     }
 
-    ghcli_fetch_with_method("POST", url, post_data, &buffer);
+    ghcli_fetch_with_method("POST", url, post_data, NULL, &buffer);
     ghcli_print_html_url(buffer);
 
     free(in.data);

--- a/src/forks.c
+++ b/src/forks.c
@@ -97,8 +97,6 @@ ghcli_get_forks(
         owner, reponame);
 
     do {
-        memset(&buffer, 0, sizeof(buffer));
-
         ghcli_fetch(url, &next_url, &buffer);
 
         json_open_buffer(&stream, buffer.data, buffer.length);

--- a/src/forks.c
+++ b/src/forks.c
@@ -77,39 +77,51 @@ parse_fork(struct json_stream *input, ghcli_fork *out)
 }
 
 int
-ghcli_get_forks(const char *owner, const char *reponame, ghcli_fork **out)
+ghcli_get_forks(
+    const char  *owner,
+    const char  *reponame,
+    int          max,
+    ghcli_fork **out)
 {
-    ghcli_fetch_buffer  buffer = {0};
-    char               *url    = NULL;
-    enum   json_type    next   = JSON_NULL;
-    struct json_stream  stream = {0};
-    int                 size   = 0;
+    ghcli_fetch_buffer  buffer   = {0};
+    char               *url      = NULL;
+    char               *next_url = NULL;
+    enum   json_type    next     = JSON_NULL;
+    struct json_stream  stream   = {0};
+    int                 size     = 0;
 
     *out = NULL;
 
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/forks",
         owner, reponame);
-    ghcli_fetch(url, NULL, &buffer);
 
-    free(url);
+    do {
+        memset(&buffer, 0, sizeof(buffer));
 
-    json_open_buffer(&stream, buffer.data, buffer.length);
-    json_set_streaming(&stream, 1);
+        ghcli_fetch(url, &next_url, &buffer);
 
-    // TODO: Poor error message
-    if ((next = json_next(&stream)) != JSON_ARRAY)
-        errx(1,
-             "Expected array in response from API "
-             "but got something else instead");
+        json_open_buffer(&stream, buffer.data, buffer.length);
+        json_set_streaming(&stream, 1);
 
-    while ((next = json_peek(&stream)) != JSON_ARRAY_END) {
-        *out = realloc(*out, sizeof(ghcli_fork) * (size + 1));
-        ghcli_fork *it = &(*out)[size++];
-        parse_fork(&stream, it);
-    }
+        // TODO: Poor error message
+        if ((next = json_next(&stream)) != JSON_ARRAY)
+            errx(1,
+                 "Expected array in response from API "
+                 "but got something else instead");
 
-    free(buffer.data);
+        while ((next = json_peek(&stream)) != JSON_ARRAY_END) {
+            *out = realloc(*out, sizeof(ghcli_fork) * (size + 1));
+            ghcli_fork *it = &(*out)[size++];
+            parse_fork(&stream, it);
+        }
+
+        json_close(&stream);
+        free(buffer.data);
+        free(url);
+    } while ((url = next_url) && (max == -1 || size < max));
+
+    free(next_url);
 
     return size;
 }

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -501,7 +501,10 @@ subcommand_issues(int argc, char *argv[])
 
     /* No issue number was given, so list all open issues */
     if (issue < 0) {
-        issues_size = ghcli_get_issues(owner, repo, all, &issues);
+        issues_size = ghcli_get_issues(
+            owner, repo,
+            all, all ? -1 : 100,
+            &issues);
         ghcli_print_issues_table(stdout, issues, issues_size);
 
         ghcli_issues_free(issues, issues_size);

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -777,7 +777,7 @@ subcommand_repos(int argc, char *argv[])
             errx(1, "repos: no actions specified");
 
         if (!owner)
-            repos_size = ghcli_get_own_repos(&repos);
+            repos_size = ghcli_get_own_repos(n, &repos);
         else
             repos_size = ghcli_get_repos(owner, n, &repos);
 

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -330,6 +330,7 @@ subcommand_pulls(int argc, char *argv[])
     int         ch         = 0;
     int         pr         = -1;
     int         pulls_size = 0;
+    int         n          = 30;     /* how many prs to fetch at least */
     bool        all        = false;
 
     /* detect whether we wanna create a PR */
@@ -343,6 +344,10 @@ subcommand_pulls(int argc, char *argv[])
           .has_arg = no_argument,
           .flag    = NULL,
           .val     = 'a' },
+        { .name    = "count",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'n' },
         { .name    = "repo",
           .has_arg = required_argument,
           .flag    = NULL,
@@ -359,7 +364,7 @@ subcommand_pulls(int argc, char *argv[])
     };
 
     /* Parse commandline options */
-    while ((ch = getopt_long(argc, argv, "o:r:p:a", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "n:o:r:p:a", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -374,6 +379,14 @@ subcommand_pulls(int argc, char *argv[])
 
             if (pr <= 0)
                 errx(1, "error: pr number is out of range");
+        } break;
+        case 'n': {
+            n = strtoul(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "error: cannot parse pr count »%s«", optarg);
+
+            if (n < -1)
+                errx(1, "error: pr count is out of range");
         } break;
         case 'a': {
             all = true;
@@ -392,7 +405,7 @@ subcommand_pulls(int argc, char *argv[])
     /* In case no explicit PR number was specified, list all
      * open PRs and exit */
     if (pr < 0) {
-        pulls_size = ghcli_get_prs(owner, repo, all, &pulls);
+        pulls_size = ghcli_get_prs(owner, repo, all, n, &pulls);
         ghcli_print_pr_table(stdout, pulls, pulls_size);
 
         ghcli_pulls_free(pulls, pulls_size);

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -439,6 +439,7 @@ subcommand_issues(int argc, char *argv[])
     char        *endptr      = NULL;
     int          ch          = 0;
     int          issue       = -1;
+    int          n           = 30;
     bool         all         = false;
 
     /* detect whether we wanna create an issue */
@@ -464,6 +465,11 @@ subcommand_issues(int argc, char *argv[])
           .has_arg = required_argument,
           .flag    = NULL,
           .val     = 'i' },
+        { .name    = "count",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'n'
+        },
         {0},
     };
 
@@ -484,6 +490,14 @@ subcommand_issues(int argc, char *argv[])
             if (issue < 0)
                 errx(1, "error: issue number is out of range");
         } break;
+        case 'n': {
+            n = strtol(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "error: cannot parse issue count");
+
+            if (n < -1)
+                errx(1, "error: issue count is out of range");
+        } break;
         case 'a':
             all = true;
             break;
@@ -501,10 +515,7 @@ subcommand_issues(int argc, char *argv[])
 
     /* No issue number was given, so list all open issues */
     if (issue < 0) {
-        issues_size = ghcli_get_issues(
-            owner, repo,
-            all, all ? -1 : 100,
-            &issues);
+        issues_size = ghcli_get_issues(owner, repo, all, n, &issues);
         ghcli_print_issues_table(stdout, issues, issues_size);
 
         ghcli_issues_free(issues, issues_size);

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -994,6 +994,7 @@ subcommand_forks(int argc, char *argv[])
     const char *owner      = NULL, *repo = NULL;
     int         forks_size = 0;
     int         ch         = 0;
+    int         count      = 30;
     bool        always_yes = false;
 
     /* detect whether we wanna create a fork */
@@ -1011,6 +1012,10 @@ subcommand_forks(int argc, char *argv[])
           .has_arg = required_argument,
           .flag    = NULL,
           .val     = 'o' },
+        { .name    = "count",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'n' },
         { .name    = "yes",
           .has_arg = no_argument,
           .flag    = NULL,
@@ -1018,7 +1023,7 @@ subcommand_forks(int argc, char *argv[])
         {0},
     };
 
-    while ((ch = getopt_long(argc, argv, "o:r:y", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "n:o:r:y", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -1029,6 +1034,12 @@ subcommand_forks(int argc, char *argv[])
         case 'y':
             always_yes = true;
             break;
+        case 'n': {
+            char *endptr = NULL;
+            count        = strtol(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "forks: unable to parse forks count argument");
+        } break;
         case '?':
         default:
             usage();
@@ -1041,7 +1052,7 @@ subcommand_forks(int argc, char *argv[])
     check_owner_and_repo(&owner, &repo);
 
     if (argc == 0) {
-        forks_size = ghcli_get_forks(owner, repo, &forks);
+        forks_size = ghcli_get_forks(owner, repo, count, &forks);
         ghcli_print_forks(stdout, forks, forks_size);
         return EXIT_SUCCESS;
     }

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -1266,7 +1266,9 @@ static struct {
 static int
 subcommand_releases(int argc, char *argv[])
 {
-    int            ch, releases_size;
+    int            ch;
+    int            releases_size;
+    int            count    = 30;
     const char    *owner    = NULL;
     const char    *repo     = NULL;
     ghcli_release *releases = NULL;
@@ -1289,10 +1291,14 @@ subcommand_releases(int argc, char *argv[])
           .has_arg = required_argument,
           .flag    = NULL,
           .val     = 'o' },
+        { .name    = "count",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'n' },
         {0}
     };
 
-    while ((ch = getopt_long(argc, argv, "o:r:", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "n:o:r:", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -1300,6 +1306,12 @@ subcommand_releases(int argc, char *argv[])
         case 'r':
             repo = optarg;
             break;
+        case 'n': {
+            char *endptr = NULL;
+            count        = strtol(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "releases: cannot parse release count");
+        } break;
         case '?':
         default:
             usage();
@@ -1311,7 +1323,7 @@ subcommand_releases(int argc, char *argv[])
 
     check_owner_and_repo(&owner, &repo);
 
-    releases_size = ghcli_get_releases(owner, repo, &releases);
+    releases_size = ghcli_get_releases(owner, repo, count, &releases);
     ghcli_print_releases(stdout, releases, releases_size);
     ghcli_free_releases(releases, releases_size);
 

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -719,13 +719,17 @@ delete_repo(bool always_yes, const char *owner, const char *repo)
 static int
 subcommand_repos(int argc, char *argv[])
 {
-    int         ch, repos_size;
+    int         ch, repos_size, n = 30;
     const char *owner      = NULL;
     const char *repo       = NULL;
     ghcli_repo *repos      = NULL;
     bool        always_yes = false;
 
     const struct option options[] = {
+        { .name    = "count",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'n' },
         { .name    = "repo",
           .has_arg = required_argument,
           .flag    = NULL,
@@ -741,7 +745,7 @@ subcommand_repos(int argc, char *argv[])
         {0},
     };
 
-    while ((ch = getopt_long(argc, argv, "o:r:y", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "n:o:r:y", options, NULL)) != -1) {
         switch (ch) {
         case 'o':
             owner = optarg;
@@ -752,6 +756,12 @@ subcommand_repos(int argc, char *argv[])
         case 'y':
             always_yes = true;
             break;
+        case 'n': {
+            char *endptr = NULL;
+            n = strtol(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "repos: cannot parse repo count");
+        } break;
         case '?':
         default:
             usage();
@@ -769,7 +779,7 @@ subcommand_repos(int argc, char *argv[])
         if (!owner)
             repos_size = ghcli_get_own_repos(&repos);
         else
-            repos_size = ghcli_get_repos(owner, &repos);
+            repos_size = ghcli_get_repos(owner, n, &repos);
 
         ghcli_print_repos_table(stdout, repos, (size_t)repos_size);
         ghcli_repos_free(repos, repos_size);

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -940,6 +940,7 @@ subcommand_gists(int argc, char *argv[])
     const char *user       = NULL;
     ghcli_gist *gists      = NULL;
     int         gists_size = 0;
+    int         count      = 30;
 
     for (size_t i = 0; i < ARRAY_SIZE(gist_subcommands); ++i) {
         if (argc > 1 && strcmp(argv[1], gist_subcommands[i].name) == 0) {
@@ -954,14 +955,24 @@ subcommand_gists(int argc, char *argv[])
           .has_arg = no_argument,
           .flag    = NULL,
           .val     = 'u' },
+        { .name    = "count",
+          .has_arg = no_argument,
+          .flag    = NULL,
+          .val     = 'n' },
         {0},
     };
 
-    while ((ch = getopt_long(argc, argv, "u:", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "n:u:", options, NULL)) != -1) {
         switch (ch) {
         case 'u':
             user = optarg;
             break;
+        case 'n': {
+            char *endptr = NULL;
+            count        = strtol(optarg, &endptr, 10);
+            if (endptr != (optarg + strlen(optarg)))
+                err(1, "gists: cannot parse gists count");
+        } break;
         case '?':
         default:
             usage();
@@ -971,7 +982,7 @@ subcommand_gists(int argc, char *argv[])
     argc -= optind;
     argv += optind;
 
-    gists_size = ghcli_get_gists(user, &gists);
+    gists_size = ghcli_get_gists(user, count, &gists);
     ghcli_print_gists_table(stdout, gists, gists_size);
     return EXIT_SUCCESS;
 }

--- a/src/gists.c
+++ b/src/gists.c
@@ -165,7 +165,7 @@ ghcli_get_gists(const char *user, ghcli_gist **out)
     else
         url = sn_asprintf("https://api.github.com/gists");
 
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, 1);
@@ -284,7 +284,7 @@ ghcli_get_gist(const char *gist_id)
 
     url = sn_asprintf("https://api.github.com/gists/%s", gist_id);
 
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, 1);
@@ -357,7 +357,7 @@ ghcli_create_gist(ghcli_new_gist opts)
         opts.file_name,
         SV_ARGS(content));
 
-    ghcli_fetch_with_method("POST", url, post_data, &fetch_buffer);
+    ghcli_fetch_with_method("POST", url, post_data, NULL, &fetch_buffer);
     ghcli_print_html_url(fetch_buffer);
 
     free(read_buffer.data);
@@ -379,7 +379,7 @@ ghcli_delete_gist(const char *gist_id, bool always_yes)
     if (!always_yes && !sn_yesno("Are you sure you want to delete this gist?"))
         errx(1, "Aborted by user");
 
-    ghcli_fetch_with_method("DELETE", url, NULL, &buffer);
+    ghcli_fetch_with_method("DELETE", url, NULL, NULL, &buffer);
 
     free(buffer.data);
     free(url);

--- a/src/gists.c
+++ b/src/gists.c
@@ -152,39 +152,46 @@ parse_gist(struct json_stream *stream, ghcli_gist *out)
 }
 
 int
-ghcli_get_gists(const char *user, ghcli_gist **out)
+ghcli_get_gists(const char *user, int max, ghcli_gist **out)
 {
-    char               *url    = NULL;
-    ghcli_fetch_buffer  buffer = {0};
-    struct json_stream  stream = {0};
-    enum   json_type    next   = JSON_NULL;
-    int                 size   = 0;
+    char               *url      = NULL;
+    char               *next_url = NULL;
+    ghcli_fetch_buffer  buffer   = {0};
+    struct json_stream  stream   = {0};
+    enum   json_type    next     = JSON_NULL;
+    int                 size     = 0;
 
     if (user)
         url = sn_asprintf("https://api.github.com/users/%s/gists", user);
     else
         url = sn_asprintf("https://api.github.com/gists");
 
-    ghcli_fetch(url, NULL, &buffer);
+    do {
+        memset(&buffer, 0, sizeof(buffer));
 
-    json_open_buffer(&stream, buffer.data, buffer.length);
-    json_set_streaming(&stream, 1);
+        ghcli_fetch(url, &next_url, &buffer);
 
-    if ((next = json_next(&stream)) != JSON_ARRAY)
-        errx(1, "Expected array in response");
+        json_open_buffer(&stream, buffer.data, buffer.length);
+        json_set_streaming(&stream, 1);
 
-    while ((next = json_peek(&stream)) == JSON_OBJECT) {
-        *out = realloc(*out, sizeof(ghcli_gist) * (size + 1));
-        ghcli_gist *it = &(*out)[size++];
-        parse_gist(&stream, it);
-    }
+        if ((next = json_next(&stream)) != JSON_ARRAY)
+            errx(1, "Expected array in response");
 
-    if ((next = json_next(&stream)) != JSON_ARRAY_END)
-        errx(1, "Expected end of array in response");
+        while ((next = json_peek(&stream)) == JSON_OBJECT) {
+            *out = realloc(*out, sizeof(ghcli_gist) * (size + 1));
+            ghcli_gist *it = &(*out)[size++];
+            parse_gist(&stream, it);
+        }
 
-    json_close(&stream);
-    free(buffer.data);
-    free(url);
+        if ((next = json_next(&stream)) != JSON_ARRAY_END)
+            errx(1, "Expected end of array in response");
+
+        json_close(&stream);
+        free(buffer.data);
+        free(url);
+    } while ((url = next_url) && (max == -1 || size < max));
+
+    free(next_url);
 
     return size;
 }

--- a/src/gists.c
+++ b/src/gists.c
@@ -167,8 +167,6 @@ ghcli_get_gists(const char *user, int max, ghcli_gist **out)
         url = sn_asprintf("https://api.github.com/gists");
 
     do {
-        memset(&buffer, 0, sizeof(buffer));
-
         ghcli_fetch(url, &next_url, &buffer);
 
         json_open_buffer(&stream, buffer.data, buffer.length);

--- a/src/issues.c
+++ b/src/issues.c
@@ -120,9 +120,7 @@ ghcli_get_issues(
         all ? "all" : "open");
 
     do {
-        next_url = NULL;
         ghcli_fetch(url, &next_url, &json_buffer);
-        free(url);
 
         json_open_buffer(&stream, json_buffer.data, json_buffer.length);
         json_set_streaming(&stream, true);
@@ -150,6 +148,7 @@ ghcli_get_issues(
         }
 
         free(json_buffer.data);
+        free(url);
         json_close(&stream);
     } while ((url = next_url) && (max == -1 || count < max));
     /* continue iterating if we have both a next_url and we are

--- a/src/issues.c
+++ b/src/issues.c
@@ -48,7 +48,7 @@ perform_submit_issue(
         "https://api.github.com/repos/"SV_FMT"/issues",
         SV_ARGS(opts.in));
 
-    ghcli_fetch_with_method("POST", url, post_fields, out);
+    ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
     free(post_fields);
     free(url);
 }
@@ -105,48 +105,58 @@ ghcli_get_issues(
     const char *owner,
     const char *reponame,
     bool all,
+    int  max,
     ghcli_issue **out)
 {
     int                 count       = 0;
     json_stream         stream      = {0};
     ghcli_fetch_buffer  json_buffer = {0};
     char               *url         = NULL;
+    char               *next_url    = NULL;
 
     url = sn_asprintf(
-        "https://api.github.com/repos/%s/%s/issues?per_page=100&state=%s",
+        "https://api.github.com/repos/%s/%s/issues?state=%s",
         owner, reponame,
         all ? "all" : "open");
-    ghcli_fetch(url, &json_buffer);
 
-    free(url);
+    do {
+        next_url = NULL;
+        ghcli_fetch(url, &next_url, &json_buffer);
+        free(url);
 
-    json_open_buffer(&stream, json_buffer.data, json_buffer.length);
-    json_set_streaming(&stream, true);
+        json_open_buffer(&stream, json_buffer.data, json_buffer.length);
+        json_set_streaming(&stream, true);
 
-    enum json_type next_token = json_next(&stream);
+        enum json_type next_token = json_next(&stream);
 
-    while ((next_token = json_peek(&stream)) != JSON_ARRAY_END) {
+        while ((next_token = json_peek(&stream)) != JSON_ARRAY_END) {
 
-        switch (next_token) {
-        case JSON_ERROR:
-            errx(1, "Parser error: %s", json_get_error(&stream));
-            break;
-        case JSON_OBJECT: {
-            *out = realloc(*out, sizeof(ghcli_issue) * (count + 1));
-            ghcli_issue *it = &(*out)[count];
-            memset(it, 0, sizeof(ghcli_issue));
-            parse_issue_entry(&stream, it);
-            count += 1;
-        } break;
-        default:
-            errx(1, "Unexpected json type in response");
-            break;
+            switch (next_token) {
+            case JSON_ERROR:
+                errx(1, "Parser error: %s", json_get_error(&stream));
+                break;
+            case JSON_OBJECT: {
+                *out = realloc(*out, sizeof(ghcli_issue) * (count + 1));
+                ghcli_issue *it = &(*out)[count];
+                memset(it, 0, sizeof(ghcli_issue));
+                parse_issue_entry(&stream, it);
+                count += 1;
+            } break;
+            default:
+                errx(1, "Unexpected json type in response");
+                break;
+            }
+
         }
 
-    }
+        free(json_buffer.data);
+        json_close(&stream);
+    } while ((url = next_url) && (max == -1 || count < max));
+    /* continue iterating if we have both a next_url and we are
+     * supposed to fetch more issues (either max is -1 thus all issues
+     * or we haven't fetched enough yet). */
 
-    free(json_buffer.data);
-    json_close(&stream);
+    free(next_url);
 
     return count;
 }
@@ -285,7 +295,7 @@ ghcli_issue_summary(
         "https://api.github.com/repos/%s/%s/issues/%d?per_page=100",
         owner, repo,
         issue_number);
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&parser, buffer.data, buffer.length);
     json_set_streaming(&parser, true);
@@ -313,7 +323,7 @@ ghcli_issue_close(const char *owner, const char *repo, int issue_number)
         issue_number);
     data = sn_asprintf("{ \"state\": \"close\"}");
 
-    ghcli_fetch_with_method("PATCH", url, data, &json_buffer);
+    ghcli_fetch_with_method("PATCH", url, data, NULL, &json_buffer);
 
     free((void *)data);
     free((void *)url);
@@ -333,7 +343,7 @@ ghcli_issue_reopen(const char *owner, const char *repo, int issue_number)
         issue_number);
     data = sn_asprintf("{ \"state\": \"open\"}");
 
-    ghcli_fetch_with_method("PATCH", url, data, &json_buffer);
+    ghcli_fetch_with_method("PATCH", url, data, NULL, &json_buffer);
 
     free((void *)data);
     free((void *)url);

--- a/src/pulls.c
+++ b/src/pulls.c
@@ -134,8 +134,6 @@ ghcli_get_prs(
         owner, reponame, all ? "all" : "open");
 
     do {
-        memset(&json_buffer, 0, sizeof(json_buffer));
-
         ghcli_fetch(url, &next_url, &json_buffer);
 
         json_open_buffer(&stream, json_buffer.data, json_buffer.length);

--- a/src/pulls.c
+++ b/src/pulls.c
@@ -59,7 +59,7 @@ perform_submit_pr(ghcli_submit_pull_options opts, ghcli_fetch_buffer *out)
         "https://api.github.com/repos/"SV_FMT"/pulls",
         SV_ARGS(opts.in));
 
-    ghcli_fetch_with_method("POST", url, post_fields, out);
+    ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
     free(post_fields);
     free(url);
 }
@@ -116,7 +116,11 @@ ghcli_pulls_free(ghcli_pull *it, int n)
 }
 
 int
-ghcli_get_prs(const char *owner, const char *reponame, bool all, ghcli_pull **out)
+ghcli_get_prs(
+    const char *owner,
+    const char *reponame,
+    bool all,
+    ghcli_pull **out)
 {
     int                 count       = 0;
     json_stream         stream      = {0};
@@ -126,7 +130,7 @@ ghcli_get_prs(const char *owner, const char *reponame, bool all, ghcli_pull **ou
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls?per_page=100&state=%s",
         owner, reponame, all ? "all" : "open");
-    ghcli_fetch(url, &json_buffer);
+    ghcli_fetch(url, NULL, &json_buffer);
 
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
@@ -422,7 +426,7 @@ ghcli_get_pull_commits(const char *url, ghcli_commit **out)
     json_stream        stream      = {0};
     ghcli_fetch_buffer json_buffer = {0};
 
-    ghcli_fetch(url, &json_buffer);
+    ghcli_fetch(url, NULL, &json_buffer);
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
 
@@ -536,7 +540,7 @@ ghcli_pr_summary(
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d",
         owner, reponame, pr_number);
-    ghcli_fetch(url, &json_buffer);
+    ghcli_fetch(url, NULL, &json_buffer);
 
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
@@ -632,7 +636,7 @@ ghcli_pr_merge(FILE *out, const char *owner, const char *reponame, int pr_number
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/merge",
         owner, reponame, pr_number);
-    ghcli_fetch_with_method("PUT", url, data, &json_buffer);
+    ghcli_fetch_with_method("PUT", url, data, NULL, &json_buffer);
     json_open_buffer(&stream, json_buffer.data, json_buffer.length);
     json_set_streaming(&stream, true);
 
@@ -671,7 +675,7 @@ ghcli_pr_close(const char *owner, const char *reponame, int pr_number)
         owner, reponame, pr_number);
     data = sn_asprintf("{ \"state\": \"closed\"}");
 
-    ghcli_fetch_with_method("PATCH", url, data, &json_buffer);
+    ghcli_fetch_with_method("PATCH", url, data, NULL, &json_buffer);
 
     free(json_buffer.data);
     free((void *)url);
@@ -690,7 +694,7 @@ ghcli_pr_reopen(const char *owner, const char *reponame, int pr_number)
         owner, reponame, pr_number);
     data = sn_asprintf("{ \"state\": \"open\"}");
 
-    ghcli_fetch_with_method("PATCH", url, data, &json_buffer);
+    ghcli_fetch_with_method("PATCH", url, data, NULL, &json_buffer);
 
     free(json_buffer.data);
     free((void *)url);

--- a/src/releases.c
+++ b/src/releases.c
@@ -108,8 +108,6 @@ ghcli_get_releases(
         owner, repo);
 
     do {
-        memset(&buffer, 0, sizeof(buffer));
-
         ghcli_fetch(url, &next_url, &buffer);
 
         json_open_buffer(&stream, buffer.data, buffer.length);

--- a/src/releases.c
+++ b/src/releases.c
@@ -102,7 +102,7 @@ ghcli_get_releases(const char *owner, const char *repo, ghcli_release **out)
         "https://api.github.com/repos/%s/%s/releases",
         owner, repo);
 
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, 1);
@@ -267,7 +267,7 @@ ghcli_create_release(const ghcli_new_release *release)
         commitish_json ? commitish_json : "",
         name_json ? name_json : "");
 
-    ghcli_fetch_with_method("POST", url, post_data, &buffer);
+    ghcli_fetch_with_method("POST", url, post_data, NULL, &buffer);
     parse_single_release(buffer, &response);
 
     printf("INFO : Release at "SV_FMT"\n", SV_ARGS(response.html_url));
@@ -307,7 +307,7 @@ ghcli_delete_release(const char *owner, const char *repo, const char *id)
         "https://api.github.com/repos/%s/%s/releases/%s",
         owner, repo, id);
 
-    ghcli_fetch_with_method("DELETE", url, NULL, &buffer);
+    ghcli_fetch_with_method("DELETE", url, NULL, NULL, &buffer);
 
     free(url);
     free(buffer.data);

--- a/src/repos.c
+++ b/src/repos.c
@@ -104,7 +104,6 @@ ghcli_get_repos(const char *owner, int max, ghcli_repo **out)
     }
 
     do {
-        memset(&buffer, 0, sizeof(buffer));
         ghcli_fetch(url, &next_url, &buffer);
 
         json_open_buffer(&stream, buffer.data, buffer.length);
@@ -197,7 +196,7 @@ ghcli_get_own_repos(int max, ghcli_repo **out)
     int                 size     = 0;
 
     do {
-        memset(&buffer, 0, sizeof(buffer));
+        buffer.length = 0;
         ghcli_fetch(url, &next_url, &buffer);
 
         json_open_buffer(&stream, buffer.data, buffer.length);

--- a/src/repos.c
+++ b/src/repos.c
@@ -102,7 +102,7 @@ ghcli_get_repos(const char *owner, ghcli_repo **out)
         url = sn_asprintf("https://api.github.com/orgs/%s/repos", owner);
     }
 
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, 1);
@@ -173,7 +173,7 @@ ghcli_repo_delete(const char *owner, const char *repo)
     url = sn_asprintf("https://api.github.com/repos/%s/%s",
                       owner, repo);
 
-    ghcli_fetch_with_method("DELETE", url, NULL, &buffer);
+    ghcli_fetch_with_method("DELETE", url, NULL, NULL, &buffer);
 
     free(buffer.data);
     free(url);
@@ -188,7 +188,7 @@ ghcli_get_own_repos(ghcli_repo **out)
     enum  json_type     next   = JSON_NULL;
     int                 size   = 0;
 
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, 1);

--- a/src/review.c
+++ b/src/review.c
@@ -90,7 +90,7 @@ ghcli_review_get_reviews(
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/reviews",
         owner, repo, pr);
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, true);
@@ -244,7 +244,7 @@ ghcli_review_get_review_comments(
     url = sn_asprintf(
         "https://api.github.com/repos/%s/%s/pulls/%d/reviews/%d/comments",
         owner, repo, pr, review_id);
-    ghcli_fetch(url, &buffer);
+    ghcli_fetch(url, NULL, &buffer);
 
     json_open_buffer(&stream, buffer.data, buffer.length);
     json_set_streaming(&stream, true);


### PR DESCRIPTION
The Github API pages results, which we haven't accounted for up until now.
This allows us to query less than 100 items at a time, but also many more.
Fixes #36
