### PR TITLE
(#46) Make ghcli-issues-create options more consistent

### DIFF
--- a/docs/ghcli-issues.1
+++ b/docs/ghcli-issues.1
@@ -12,7 +12,7 @@
 .Op Ar actions...
 .Nm
 .Cm create
-.Op Fl i Ar owner/repo
+.Op Fl o Ar owner Fl r Ar repo
 .Op Fl y
 .Sh DESCRIPTION
 Use

--- a/include/ghcli/config.h
+++ b/include/ghcli/config.h
@@ -38,6 +38,7 @@ char  *ghcli_config_get_apibase(void);
 sn_sv  ghcli_config_get_token(void);
 sn_sv  ghcli_config_get_account(void);
 sn_sv  ghcli_config_get_upstream(void);
+void   ghcli_config_get_upstream_parts(sn_sv *owner, sn_sv *repo);
 sn_sv  ghcli_config_get_base(void);
 
 #endif /* CONFIG_H */

--- a/include/ghcli/issues.h
+++ b/include/ghcli/issues.h
@@ -59,7 +59,8 @@ struct ghcli_issue_details {
 };
 
 struct ghcli_submit_issue_options {
-    sn_sv in;
+    sn_sv owner;
+    sn_sv repo;
     sn_sv title;
     sn_sv body;
     bool  always_yes;

--- a/src/config.c
+++ b/src/config.c
@@ -301,6 +301,17 @@ ghcli_config_get_upstream(void)
     return local_config.upstream;
 }
 
+void
+ghcli_config_get_upstream_parts(sn_sv *owner, sn_sv *repo)
+{
+    sn_sv upstream   = ghcli_config_get_upstream();
+    *owner           = sn_sv_chop_until(&upstream, '/');
+    /* TODO: Sanity check */
+    upstream.data   += 1;
+    upstream.length -= 1;
+    *repo            = upstream;
+}
+
 sn_sv
 ghcli_config_get_base(void)
 {

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -120,10 +120,14 @@ subcommand_issue_create(int argc, char *argv[])
     ghcli_submit_issue_options opts   = {0};
 
     const struct option options[] = {
-        { .name    = "in",
+        { .name    = "owner",
           .has_arg = required_argument,
           .flag    = NULL,
-          .val     = 'i' },
+          .val     = 'o' },
+        { .name    = "repo",
+          .has_arg = required_argument,
+          .flag    = NULL,
+          .val     = 'r' },
         { .name    = "yes",
           .has_arg = no_argument,
           .flag    = NULL,
@@ -131,10 +135,13 @@ subcommand_issue_create(int argc, char *argv[])
         {0},
     };
 
-    while ((ch = getopt_long(argc, argv, "i:", options, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "o:r:", options, NULL)) != -1) {
         switch (ch) {
-        case 'i':
-            opts.in    = SV(optarg);
+        case 'o':
+            opts.owner = SV(optarg);
+            break;
+        case 'r':
+            opts.repo = SV(optarg);
             break;
         case 'y':
             opts.always_yes = true;
@@ -146,12 +153,13 @@ subcommand_issue_create(int argc, char *argv[])
     argc -= optind;
     argv += optind;
 
-    if (!opts.in.length) {
-        if (!(opts.in = ghcli_config_get_upstream()).length)
+    if (!opts.owner.length || !opts.repo.length) {
+        ghcli_config_get_upstream_parts(&opts.owner, &opts.repo);
+        if (!opts.owner.length || !opts.repo.length)
             errx(1,
                  "error: Target repo for the issue to be created "
-                 "in is missing. Please either specify '--in owner/repo'"
-                 " or set pr.upstream in .ghcli.");
+                 "in is missing. Please either specify '-o owner' "
+                 "and '-r repo' or set pr.upstream in .ghcli.");
     }
 
     if (argc != 1)

--- a/src/issues.c
+++ b/src/issues.c
@@ -46,9 +46,10 @@ perform_submit_issue(
         "{ \"title\": \""SV_FMT"\", \"body\": \""SV_FMT"\" }",
         SV_ARGS(opts.title), SV_ARGS(opts.body));
     char *url         = sn_asprintf(
-        "%s/repos/"SV_FMT"/issues",
+        "%s/repos/"SV_FMT"/"SV_FMT"/issues",
         ghcli_config_get_apibase(),
-        SV_ARGS(opts.in));
+        SV_ARGS(opts.owner),
+        SV_ARGS(opts.repo));
 
     ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
     free(post_fields);
@@ -388,10 +389,11 @@ ghcli_issue_submit(ghcli_submit_issue_options opts)
             "The following issue will be created:\n"
             "\n"
             "TITLE   : "SV_FMT"\n"
-            "IN      : "SV_FMT"\n"
+            "OWNER   : "SV_FMT"\n"
+            "REPO    : "SV_FMT"\n"
             "MESSAGE :\n"SV_FMT"\n",
-            SV_ARGS(opts.title),SV_ARGS(opts.in),
-            SV_ARGS(body));
+            SV_ARGS(opts.title), SV_ARGS(opts.owner),
+            SV_ARGS(opts.repo), SV_ARGS(body));
 
     fputc('\n', stdout);
 

--- a/src/issues.c
+++ b/src/issues.c
@@ -39,8 +39,8 @@
 
 static void
 perform_submit_issue(
-    ghcli_submit_issue_options opts,
-    ghcli_fetch_buffer *out)
+    ghcli_submit_issue_options  opts,
+    ghcli_fetch_buffer         *out)
 {
     char *post_fields = sn_asprintf(
         "{ \"title\": \""SV_FMT"\", \"body\": \""SV_FMT"\" }",


### PR DESCRIPTION
Instead of providing the -i flag, split it in -o and -r.
Fixes #46
