### PR TITLE
add remotes when forking

### DIFF
--- a/include/ghcli/gitconfig.h
+++ b/include/ghcli/gitconfig.h
@@ -34,5 +34,6 @@
 
 void  ghcli_gitconfig_get_repo(const char **owner, const char **repo);
 sn_sv ghcli_gitconfig_get_current_branch(void);
+void  ghcli_gitconfig_add_fork_remote(const char *org, const char *repo);
 
 #endif /* GITCONFIG_H */


### PR DESCRIPTION
The user may choose to add remotes. This shuffles around the origin to upstream and then points a new origin at the newly created fork.
