### PR TITLE
(#54) Forges as plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 /include/ghcli/github/releases.h~
 /src/github/releases.c~
 /src/github/releases.o
+/include/ghcli/forges.h~
+/src/forges.c~

--- a/Makefile
+++ b/Makefile
@@ -17,28 +17,29 @@ CPPFLAGS			=	-D_XOPEN_SOURCE=600 \
 					-DGHCLI_VERSION_STRING=\"${GHCLI_VERSION}\"
 
 # List the source files for each binary to be built
-ghcli_SRCS			=	src/ghcli.c			\
+ghcli_SRCS			=	src/comments.c			\
+					src/config.c			\
 					src/curl.c			\
 					src/editor.c			\
-					src/issues.c			\
-					src/comments.c			\
-					src/gitconfig.c			\
-					src/pulls.c			\
+					src/forges.c			\
 					src/forks.c			\
-					src/repos.c			\
+					src/ghcli.c			\
 					src/gists.c			\
-					src/review.c			\
-					src/releases.c			\
-					src/json_util.c			\
-					src/config.c			\
-					src/github/repos.c		\
+					src/gitconfig.c			\
 					src/github/comments.c		\
 					src/github/forks.c		\
-					src/github/pulls.c		\
 					src/github/issues.c		\
+					src/github/pulls.c		\
 					src/github/releases.c		\
-					thirdparty/sn/sn.c		\
-					thirdparty/pdjson/pdjson.c
+					src/github/repos.c		\
+					src/issues.c			\
+					src/json_util.c			\
+					src/pulls.c			\
+					src/releases.c			\
+					src/repos.c			\
+					src/review.c			\
+					thirdparty/pdjson/pdjson.c	\
+					thirdparty/sn/sn.c
 
 LIBADD				=	libcurl
 

--- a/include/ghcli/forges.h
+++ b/include/ghcli/forges.h
@@ -52,7 +52,7 @@ struct ghcli_forge_descriptor {
 
     /**
      * List comments on the given issue */
-    int (*issue_comments)(
+    int (*get_issue_comments)(
         const char     *owner,
         const char     *repo,
         int             issue,

--- a/include/ghcli/forges.h
+++ b/include/ghcli/forges.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FORGES_H
+#define FORGES_H
+
+#include <ghcli/comments.h>
+#include <ghcli/curl.h>
+#include <ghcli/forks.h>
+#include <ghcli/issues.h>
+#include <ghcli/pulls.h>
+#include <ghcli/releases.h>
+#include <ghcli/repos.h>
+
+typedef struct ghcli_forge_descriptor ghcli_forge_descriptor;
+
+/**
+ * Struct of function pointers to perform actions in the given
+ * forge. It is like a plugin system to dispatch. */
+struct ghcli_forge_descriptor {
+    /**
+     * Submit a comment to a pull/mr or issue */
+    void (*perform_submit_comment)(
+        ghcli_submit_comment_opts  opts,
+        ghcli_fetch_buffer        *out);
+
+    /**
+     * List comments on the given issue */
+    int (*issue_comments)(
+        const char     *owner,
+        const char     *repo,
+        int             issue,
+        ghcli_comment **out);
+
+    /**
+     * List forks of the given repo */
+    int (*get_forks)(
+        const char  *owner,
+        const char  *repo,
+        int          max,
+        ghcli_fork **out);
+
+    /**
+     * Fork the given repo into the owner _in */
+    void (*fork_create)(
+        const char *owner,
+        const char *repo,
+        const char *_in);
+
+    /**
+     * Get a list of issues on the given repo */
+    int (*get_issues)(
+        const char   *owner,
+        const char   *repo,
+        bool          all,
+        int           max,
+        ghcli_issue **out);
+
+    /**
+     * Get a summary of an issue */
+    void (*get_issue_summary)(
+        const char          *owner,
+        const char          *repo,
+        int                  issue_number,
+        ghcli_issue_details *out);
+
+    /**
+     * Close the given issue */
+    void (*issue_close)(
+        const char *owner,
+        const char *repo,
+        int         issue_number);
+
+    /**
+     * Reopen the given issue */
+    void (*issue_reopen)(
+        const char *owner,
+        const char *repo,
+        int         issue_number);
+
+    /**
+     * Submit an issue */
+    void (*perform_submit_issue)(
+        ghcli_submit_issue_options  opts,
+        ghcli_fetch_buffer         *out);
+
+    /**
+     * Get a list of PRs/MRs on the given repo */
+    int (*get_prs)(
+        const char  *owner,
+        const char  *reponame,
+        bool         all,
+        int          max,
+        ghcli_pull **out);
+
+    /**
+     * Print a diff of the changes of a PR/MR to the stream */
+    void (*print_pr_diff)(
+        FILE       *stream,
+        const char *owner,
+        const char *reponame,
+        int         pr_number);
+
+    /**
+     * Merge the given PR/MR */
+    void (*pr_merge)(
+        FILE       *out,
+        const char *owner,
+        const char *reponame,
+        int         pr_number);
+
+    /**
+     * Reopen the given PR/MR */
+    void (*pr_reopen)(
+        const char *owner,
+        const char *reponame,
+        int         pr_number);
+
+    /**
+     * Close the given PR/MR */
+    void (*pr_close)(
+        const char *owner,
+        const char *reponame,
+        int         pr_number);
+
+    /**
+     * Submit PR/MR */
+    void (*perform_submit_pr)(
+        ghcli_submit_pull_options  opts,
+        ghcli_fetch_buffer        *out);
+
+    /**
+     * Get a list of commits in the given PR/MR */
+    int (*get_pull_commits)(
+        const char    *owner,
+        const char    *repo,
+        int            pr_number,
+        ghcli_commit **out);
+
+    /**
+     * Get a summary of the given PR/MR */
+    void (*get_pull_summary)(
+        const char         *owner,
+        const char         *repo,
+        int                 pr_number,
+        ghcli_pull_summary *out);
+
+    /**
+     * Get a list of releases in the given repo */
+    int (*get_releases)(
+        const char     *owner,
+        const char     *repo,
+        int             max,
+        ghcli_release **out);
+
+    /**
+     * Create a new release */
+    void (*create_release)(
+        const ghcli_new_release *release);
+
+    /**
+     * Delete the release */
+    void (*delete_release)(
+        const char *owner,
+        const char *repo,
+        const char *id);
+
+    /**
+     * Get a list of repos of the given owner */
+    int (*get_repos)(
+        const char  *owner,
+        int          max,
+        ghcli_repo **out);
+
+    /**
+     * Get a list of your own repos */
+    int (*get_own_repos)(
+        int          max,
+        ghcli_repo **out);
+
+    /**
+     * Delete the given repo */
+    void (*repo_delete)(
+        const char *owner,
+        const char *repo);
+};
+
+const ghcli_forge_descriptor *ghcli_forge(void);
+
+#endif /* FORGES_H */

--- a/include/ghcli/github/comments.h
+++ b/include/ghcli/github/comments.h
@@ -37,12 +37,6 @@ void github_perform_submit_comment(
     ghcli_submit_comment_opts  opts,
     ghcli_fetch_buffer        *out);
 
-void github_issue_comments(
-    FILE       *stream,
-    const char *owner,
-    const char *repo,
-    int         issue);
-
 int github_get_issue_comments(
     const char     *owner,
     const char     *repo,

--- a/src/comments.c
+++ b/src/comments.c
@@ -28,25 +28,11 @@
  */
 
 #include <ghcli/comments.h>
-#include <ghcli/config.h>
 #include <ghcli/editor.h>
+#include <ghcli/forges.h>
 #include <ghcli/github/comments.h>
 #include <ghcli/json_util.h>
 #include <sn/sn.h>
-
-static void
-perform_submit_comment(
-    ghcli_submit_comment_opts  opts,
-    ghcli_fetch_buffer        *out)
-{
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_perform_submit_comment(opts, out);
-        break;
-    default:
-        sn_unimplemented;
-    }
-}
 
 static void
 ghcli_issue_comment_free(ghcli_comment *it)
@@ -71,25 +57,6 @@ ghcli_print_comment_list(
     }
 }
 
-static int
-ghcli_get_issue_comments(
-    const char     *owner,
-    const char     *repo,
-    int             issue,
-    ghcli_comment **out)
-{
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        return github_get_issue_comments(owner, repo, issue, out);
-    } break;
-    default: {
-        sn_unimplemented;
-    } break;
-    }
-
-    return -1;
-}
-
 void
 ghcli_issue_comments(
     FILE       *stream,
@@ -100,7 +67,7 @@ ghcli_issue_comments(
     ghcli_comment *comments = NULL;
     int            n        = -1;
 
-    n = ghcli_get_issue_comments(owner, repo, issue, &comments);
+    n = ghcli_forge()->get_issue_comments(owner, repo, issue, &comments);
     ghcli_print_comment_list(stream, comments, (size_t)n);
 
     for (int i = 0; i < n; ++i)
@@ -146,7 +113,7 @@ ghcli_comment_submit(ghcli_submit_comment_opts opts)
             errx(1, "Aborted by user");
     }
 
-    perform_submit_comment(opts, &buffer);
+    ghcli_forge()->perform_submit_comment(opts, &buffer);
     ghcli_print_html_url(buffer);
 
     free(buffer.data);

--- a/src/forges.c
+++ b/src/forges.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include <ghcli/config.h>
+#include <ghcli/forges.h>
+
+#include <ghcli/github/comments.h>
+#include <ghcli/github/forks.h>
+#include <ghcli/github/issues.h>
+#include <ghcli/github/pulls.h>
+#include <ghcli/github/releases.h>
+#include <ghcli/github/repos.h>
+
+static ghcli_forge_descriptor
+github_forge_descriptor =
+{
+    .perform_submit_comment = github_perform_submit_comment,
+    .issue_comments         = github_get_issue_comments,
+    .get_forks              = github_get_forks,
+    .fork_create            = github_fork_create,
+    .get_issues             = github_get_issues,
+    .get_issue_summary      = github_get_issue_summary,
+    .issue_close            = github_issue_close,
+    .issue_reopen           = github_issue_reopen,
+    .perform_submit_issue   = github_perform_submit_issue,
+    .get_prs                = github_get_prs,
+    .print_pr_diff          = github_print_pr_diff,
+    .pr_merge               = github_pr_merge,
+    .pr_reopen              = github_pr_reopen,
+    .pr_close               = github_pr_close,
+    .perform_submit_pr      = github_perform_submit_pr,
+    .get_pull_commits       = github_get_pull_commits,
+    .get_pull_summary       = github_get_pull_summary,
+    .get_releases           = github_get_releases,
+    .create_release         = github_create_release,
+    .delete_release         = github_delete_release,
+    .get_repos              = github_get_repos,
+    .get_own_repos          = github_get_own_repos,
+    .repo_delete            = github_repo_delete,
+};
+
+const ghcli_forge_descriptor *
+ghcli_forge(void)
+{
+    switch (ghcli_config_get_forge_type()) {
+    case GHCLI_FORGE_GITHUB:
+        return &github_forge_descriptor;
+    default:
+        sn_unimplemented;
+    }
+    return NULL;
+}

--- a/src/forges.c
+++ b/src/forges.c
@@ -43,7 +43,7 @@ static ghcli_forge_descriptor
 github_forge_descriptor =
 {
     .perform_submit_comment = github_perform_submit_comment,
-    .issue_comments         = github_get_issue_comments,
+    .get_issue_comments     = github_get_issue_comments,
     .get_forks              = github_get_forks,
     .fork_create            = github_fork_create,
     .get_issues             = github_get_issues,

--- a/src/forks.c
+++ b/src/forks.c
@@ -27,7 +27,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ghcli/config.h>
+#include <ghcli/forges.h>
 #include <ghcli/forks.h>
 #include <ghcli/github/forks.h>
 
@@ -38,13 +38,7 @@ ghcli_get_forks(
     int          max,
     ghcli_fork **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_forks(owner, repo, max, out);
-    default:
-        sn_unimplemented;
-    }
-    return -1;
+    return ghcli_forge()->get_forks(owner, repo, max, out);
 }
 
 void
@@ -88,12 +82,5 @@ ghcli_print_forks(
 void
 ghcli_fork_create(const char *owner, const char *repo, const char *_in)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_fork_create(owner, repo, _in);
-        break;
-    default:
-        sn_unimplemented;
-        break;
-    }
+    ghcli_forge()->fork_create(owner, repo, _in);
 }

--- a/src/pulls.c
+++ b/src/pulls.c
@@ -27,24 +27,12 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ghcli/config.h>
 #include <ghcli/editor.h>
+#include <ghcli/forges.h>
 #include <ghcli/github/pulls.h>
 #include <ghcli/json_util.h>
 #include <ghcli/pulls.h>
 #include <sn/sn.h>
-
-static void
-perform_submit_pr(ghcli_submit_pull_options opts, ghcli_fetch_buffer *out)
-{
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        github_perform_submit_pr(opts, out);
-    } break;
-    default:
-        sn_unimplemented;
-    }
-}
 
 void
 ghcli_pulls_free(ghcli_pull *it, int n)
@@ -64,14 +52,7 @@ ghcli_get_prs(
     int          max,
     ghcli_pull **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_prs(owner, repo, all, max, out);
-    default:
-        sn_unimplemented;
-        break;
-    }
-    return -1;
+    return ghcli_forge()->get_prs(owner, repo, all, max, out);
 }
 
 void
@@ -119,14 +100,7 @@ ghcli_print_pr_diff(
     const char *reponame,
     int         pr_number)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        github_print_pr_diff(stream, owner, reponame, pr_number);
-    } break;
-    default: {
-        sn_unimplemented;
-    } break;
-    }
+    ghcli_forge()->print_pr_diff(stream, owner, reponame, pr_number);
 }
 
 static void
@@ -174,13 +148,7 @@ ghcli_get_pull_commits(
     int            pr_number,
     ghcli_commit **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_pull_commits(owner, repo, pr_number, out);
-    default:
-        sn_unimplemented;
-    }
-    return -1;
+    return ghcli_forge()->get_pull_commits(owner, repo, pr_number, out);
 }
 
 /**
@@ -262,14 +230,7 @@ ghcli_get_pull_summary(
     int                 pr_number,
     ghcli_pull_summary *out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_get_pull_summary(owner, repo, pr_number, out);
-        break;
-    default:
-        sn_unimplemented;
-        break;
-    }
+    ghcli_forge()->get_pull_summary(owner, repo, pr_number, out);
 }
 
 void
@@ -341,7 +302,7 @@ ghcli_pr_submit(ghcli_submit_pull_options opts)
         if (!sn_yesno("Do you want to continue?"))
             errx(1, "PR aborted.");
 
-    perform_submit_pr(opts, &json_buffer);
+    ghcli_forge()->perform_submit_pr(opts, &json_buffer);
 
     ghcli_print_html_url(json_buffer);
 
@@ -357,38 +318,17 @@ ghcli_pr_merge(
     const char *reponame,
     int         pr_number)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        github_pr_merge(out, owner, reponame, pr_number);
-    } break;
-    default: {
-        sn_unimplemented;
-    } break;
-    }
+    ghcli_forge()->pr_merge(out, owner, reponame, pr_number);
 }
 
 void
 ghcli_pr_close(const char *owner, const char *reponame, int pr_number)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        github_pr_close(owner, reponame, pr_number);
-    } break;
-    default: {
-        sn_unimplemented;
-    } break;
-    }
+    ghcli_forge()->pr_close(owner, reponame, pr_number);
 }
 
 void
 ghcli_pr_reopen(const char *owner, const char *reponame, int pr_number)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB: {
-        github_pr_reopen(owner, reponame, pr_number);
-    } break;
-    default: {
-        sn_unimplemented;
-    } break;
-    }
+    ghcli_forge()->pr_reopen(owner, reponame, pr_number);
 }

--- a/src/releases.c
+++ b/src/releases.c
@@ -27,7 +27,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ghcli/config.h>
+#include <ghcli/forges.h>
 #include <ghcli/github/releases.h>
 #include <ghcli/releases.h>
 
@@ -41,13 +41,7 @@ ghcli_get_releases(
     int             max,
     ghcli_release **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_releases(owner, repo, max, out);
-    default:
-        sn_unimplemented;
-    }
-    return -1;
+    return ghcli_forge()->get_releases(owner, repo, max, out);
 }
 
 static void
@@ -116,14 +110,7 @@ ghcli_free_releases(ghcli_release *releases, int releases_size)
 void
 ghcli_create_release(const ghcli_new_release *release)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_create_release(release);
-        break;
-    default:
-        sn_unimplemented;
-        break;
-    }
+    ghcli_forge()->create_release(release);
 }
 
 void
@@ -138,12 +125,5 @@ ghcli_release_push_asset(ghcli_new_release *release, ghcli_release_asset asset)
 void
 ghcli_delete_release(const char *owner, const char *repo, const char *id)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_delete_release(owner, repo, id);
-        break;
-    default:
-        sn_unimplemented;
-        break;
-    }
+    ghcli_forge()->delete_release(owner, repo, id);
 }

--- a/src/repos.c
+++ b/src/repos.c
@@ -27,23 +27,16 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ghcli/config.h>
-#include <ghcli/repos.h>
+#include <ghcli/forges.h>
 #include <ghcli/github/repos.h>
+#include <ghcli/repos.h>
 
 #include <stdlib.h>
 
 int
 ghcli_get_repos(const char *owner, int max, ghcli_repo **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_repos(owner, max, out);
-    default:
-        sn_unimplemented;
-    }
-
-    return -1;
+    return ghcli_forge()->get_repos(owner, max, out);
 }
 
 
@@ -102,24 +95,11 @@ ghcli_repos_free(ghcli_repo *repos, size_t repos_size)
 int
 ghcli_get_own_repos(int max, ghcli_repo **out)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        return github_get_own_repos(max, out);
-    default:
-        sn_unimplemented;
-    }
-
-    return -1;
+    return ghcli_forge()->get_own_repos(max, out);
 }
 
 void
 ghcli_repo_delete(const char *owner, const char *repo)
 {
-    switch (ghcli_config_get_forge_type()) {
-    case GHCLI_FORGE_GITHUB:
-        github_repo_delete(owner, repo);
-        break;
-    default:
-        sn_unimplemented;
-    }
+    ghcli_forge()->repo_delete(owner, repo);
 }


### PR DESCRIPTION
This moves all the forge dependant stuff into a plugin type structure making it easy to just swap them out.
