### PR TITLE
(#64) Properly print GitLab API error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 /src/gitlab/merge_requests.c~
 /src/gitlab/merge_requests.o
 /src/gitlab/repos.o
+/src/github/api.o
+/src/gitlab/api.o

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ghcli_SRCS			=	src/comments.c			\
 					src/ghcli.c			\
 					src/gists.c			\
 					src/gitconfig.c			\
+					src/github/api.c		\
 					src/github/config.c		\
 					src/github/comments.c		\
 					src/github/forks.c		\
@@ -33,6 +34,7 @@ ghcli_SRCS			=	src/comments.c			\
 					src/github/pulls.c		\
 					src/github/releases.c		\
 					src/github/repos.c		\
+					src/gitlab/api.c		\
 					src/gitlab/config.c		\
 					src/gitlab/issues.c		\
 					src/gitlab/merge_requests.c	\

--- a/include/ghcli/forges.h
+++ b/include/ghcli/forges.h
@@ -219,6 +219,10 @@ struct ghcli_forge_descriptor {
     sn_sv (*get_account)(void);
 
     /**
+     * Get the error string from the API */
+    const char *(*get_api_error_string)(ghcli_fetch_buffer *);
+
+    /**
      * A key in the user json object sent by the API that represents
      * the user name */
     const char *user_object_key;

--- a/include/ghcli/github/api.h
+++ b/include/ghcli/github/api.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GITHUB_API_H
+#define GITHUB_API_H
+
+#include <ghcli/curl.h>
+
+const char *github_api_error_string(ghcli_fetch_buffer *it);
+
+#endif /* GITHUB_API_H */

--- a/include/ghcli/gitlab/api.h
+++ b/include/ghcli/gitlab/api.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GITLAB_API_H
+#define GITLAB_API_H
+
+#include <ghcli/curl.h>
+
+const char *gitlab_api_error_string(ghcli_fetch_buffer *it);
+
+#endif /* GITLAB_API_H */

--- a/src/curl.c
+++ b/src/curl.c
@@ -29,36 +29,14 @@
 
 #include <string.h>
 
-#include <ghcli/curl.h>
 #include <ghcli/config.h>
+#include <ghcli/curl.h>
+#include <ghcli/forges.h>
 #include <ghcli/json_util.h>
 
 #include <curl/curl.h>
 #include <sn/sn.h>
 #include <pdjson/pdjson.h>
-
-const char *
-ghcli_api_error_string(ghcli_fetch_buffer *it)
-{
-    struct json_stream stream = {0};
-    enum json_type     next   = JSON_NULL;
-
-    if (!it->length)
-        return NULL;
-
-    json_open_buffer(&stream, it->data, it->length);
-    json_set_streaming(&stream, true);
-
-    while ((next = json_next(&stream)) != JSON_OBJECT_END) {
-        char *key = get_string(&stream);
-        if (strcmp(key, "message") == 0)
-            return get_string(&stream);
-
-        free(key);
-    }
-
-    return "<No message key in error response object>";
-}
 
 static void
 ghcli_curl_check_api_error(
@@ -83,7 +61,7 @@ ghcli_curl_check_api_error(
              "error: request to %s failed with code %ld\n"
              "     : API error: %s",
              url, status_code,
-             ghcli_api_error_string(result));
+             ghcli_forge()->get_api_error_string(result));
     }
 }
 

--- a/src/forges.c
+++ b/src/forges.c
@@ -32,6 +32,7 @@
 #include <ghcli/config.h>
 #include <ghcli/forges.h>
 
+#include <ghcli/github/api.h>
 #include <ghcli/github/comments.h>
 #include <ghcli/github/config.h>
 #include <ghcli/github/forks.h>
@@ -40,6 +41,7 @@
 #include <ghcli/github/releases.h>
 #include <ghcli/github/repos.h>
 
+#include <ghcli/gitlab/api.h>
 #include <ghcli/gitlab/config.h>
 #include <ghcli/gitlab/issues.h>
 #include <ghcli/gitlab/merge_requests.h>
@@ -72,6 +74,7 @@ github_forge_descriptor =
     .repo_delete            = github_repo_delete,
     .get_authheader         = github_get_authheader,
     .get_account            = github_get_account,
+    .get_api_error_string   = github_api_error_string,
     .user_object_key        = "login",
     .html_url_key           = "html_url",
 };
@@ -104,6 +107,7 @@ gitlab_forge_descriptor =
     /* .repo_delete            = gitlab_repo_delete, */
     .get_authheader         = gitlab_get_authheader,
     .get_account            = gitlab_get_account,
+    .get_api_error_string   = gitlab_api_error_string,
     .user_object_key        = "username",
     .html_url_key           = "web_url",
 };

--- a/src/github/api.c
+++ b/src/github/api.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ghcli/github/api.h>
+#include <ghcli/json_util.h>
+
+#include <pdjson/pdjson.h>
+
+const char *
+github_api_error_string(ghcli_fetch_buffer *it)
+{
+    struct json_stream stream = {0};
+    enum json_type     next   = JSON_NULL;
+
+    if (!it->length)
+        return NULL;
+
+    json_open_buffer(&stream, it->data, it->length);
+    json_set_streaming(&stream, true);
+
+    while ((next = json_next(&stream)) != JSON_OBJECT_END) {
+        char *key = get_string(&stream);
+        if (strcmp(key, "message") == 0)
+            return get_string(&stream);
+
+        free(key);
+    }
+
+    return "<No message key in error response object>";
+}

--- a/src/gitlab/api.c
+++ b/src/gitlab/api.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ghcli/gitlab/api.h>
+#include <ghcli/json_util.h>
+
+#include <pdjson/pdjson.h>
+
+const char *
+gitlab_api_error_string(ghcli_fetch_buffer *it)
+{
+    struct json_stream stream = {0};
+    enum json_type     next   = JSON_NULL;
+
+    if (!it->length)
+        return NULL;
+
+    json_open_buffer(&stream, it->data, it->length);
+    json_set_streaming(&stream, true);
+
+    while ((next = json_next(&stream)) != JSON_OBJECT_END) {
+        char *key = get_string(&stream);
+        if (strcmp(key, "message") == 0) {
+            if ((next = json_peek(&stream)) == JSON_STRING)
+                return get_string(&stream);
+            else if ((next = json_next(&stream)) == JSON_ARRAY)
+                return get_string(&stream);
+            else if (next == JSON_ARRAY_END)
+                ;
+            else
+                errx(1, "error retrieving error message from GitLab API response");
+        }
+        free(key);
+    }
+
+    return "<No message key in error response object>";
+}


### PR DESCRIPTION
Fixes #64
