### PR TITLE
(#57) Gitlab comments support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 /src/gitlab/repos.o
 /src/github/api.o
 /src/gitlab/api.o
+/include/ghcli/gitlab/comments.h~
+/src/gitlab/comments.c~
+/src/gitlab/comments.o

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ghcli_SRCS			=	src/comments.c			\
 					src/github/releases.c		\
 					src/github/repos.c		\
 					src/gitlab/api.c		\
+					src/gitlab/comments.c		\
 					src/gitlab/config.c		\
 					src/gitlab/issues.c		\
 					src/gitlab/merge_requests.c	\

--- a/include/ghcli/comments.h
+++ b/include/ghcli/comments.h
@@ -46,10 +46,11 @@ struct ghcli_comment {
 };
 
 struct ghcli_submit_comment_opts {
-    const char *owner, *repo;
-    int         issue;
-    sn_sv       message;
-    bool        always_yes;
+    enum comment_target_type { ISSUE_COMMENT, PR_COMMENT }  target_type;
+    const char                                             *owner, *repo;
+    int                                                     target_id;
+    sn_sv                                                   message;
+    bool                                                    always_yes;
 };
 
 int  ghcli_get_comments(

--- a/include/ghcli/comments.h
+++ b/include/ghcli/comments.h
@@ -53,14 +53,16 @@ struct ghcli_submit_comment_opts {
     bool                                                    always_yes;
 };
 
-int  ghcli_get_comments(
-    const char *url,
-    ghcli_comment **comments);
 void ghcli_print_comment_list(
     FILE *stream,
     ghcli_comment *comments,
     size_t comments_size);
 void ghcli_issue_comments(
+    FILE *stream,
+    const char *owner,
+    const char *repo,
+    int issue);
+void ghcli_pull_comments(
     FILE *stream,
     const char *owner,
     const char *repo,

--- a/include/ghcli/forges.h
+++ b/include/ghcli/forges.h
@@ -59,6 +59,14 @@ struct ghcli_forge_descriptor {
         ghcli_comment **out);
 
     /**
+     * List comments on the given PR */
+    int (*get_pull_comments)(
+        const char     *owner,
+        const char     *repo,
+        int             pr,
+        ghcli_comment **out);
+
+    /**
      * List forks of the given repo */
     int (*get_forks)(
         const char  *owner,

--- a/include/ghcli/github/comments.h
+++ b/include/ghcli/github/comments.h
@@ -37,7 +37,7 @@ void github_perform_submit_comment(
     ghcli_submit_comment_opts  opts,
     ghcli_fetch_buffer        *out);
 
-int github_get_issue_comments(
+int github_get_comments(
     const char     *owner,
     const char     *repo,
     int             issue,

--- a/include/ghcli/gitlab/comments.h
+++ b/include/ghcli/gitlab/comments.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GITLAB_COMMENTS_H
+#define GITLAB_COMMENTS_H
+
+#include <ghcli/comments.h>
+#include <ghcli/curl.h>
+
+void gitlab_perform_submit_comment(
+    ghcli_submit_comment_opts  opts,
+    ghcli_fetch_buffer        *out);
+
+#endif /* GITLAB_COMMENTS_H */

--- a/include/ghcli/gitlab/comments.h
+++ b/include/ghcli/gitlab/comments.h
@@ -37,4 +37,16 @@ void gitlab_perform_submit_comment(
     ghcli_submit_comment_opts  opts,
     ghcli_fetch_buffer        *out);
 
+int gitlab_get_issue_comments(
+    const char     *owner,
+    const char     *repo,
+    int             issue,
+    ghcli_comment **out);
+
+int gitlab_get_mr_comments(
+    const char     *owner,
+    const char     *repo,
+    int             issue,
+    ghcli_comment **out);
+
 #endif /* GITLAB_COMMENTS_H */

--- a/src/comments.c
+++ b/src/comments.c
@@ -77,6 +77,25 @@ ghcli_issue_comments(
     free(comments);
 }
 
+void
+ghcli_pull_comments(
+    FILE       *stream,
+    const char *owner,
+    const char *repo,
+    int         issue)
+{
+    ghcli_comment *comments = NULL;
+    int            n        = -1;
+
+    n = ghcli_forge()->get_pull_comments(owner, repo, issue, &comments);
+    ghcli_print_comment_list(stream, comments, (size_t)n);
+
+    for (int i = 0; i < n; ++i)
+        ghcli_issue_comment_free(&comments[i]);
+
+    free(comments);
+}
+
 static void
 comment_init(FILE *f, void *_data)
 {

--- a/src/comments.c
+++ b/src/comments.c
@@ -27,6 +27,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ghcli/config.h>
 #include <ghcli/comments.h>
 #include <ghcli/editor.h>
 #include <ghcli/forges.h>
@@ -79,15 +80,32 @@ ghcli_issue_comments(
 static void
 comment_init(FILE *f, void *_data)
 {
-    ghcli_submit_comment_opts *info = _data;
+    ghcli_submit_comment_opts *info        = _data;
+    const char                *target_type = NULL;
+
+    switch (info->target_type) {
+    case ISSUE_COMMENT:
+        target_type = "issue";
+        break;
+    case PR_COMMENT: {
+        switch (ghcli_config_get_forge_type()) {
+        case GHCLI_FORGE_GITHUB:
+            target_type = "Pull Request";
+            break;
+        case GHCLI_FORGE_GITLAB:
+            target_type = "Merge Request";
+            break;
+        }
+    } break;
+    }
 
     fprintf(
         f,
         "# Enter your comment below, save and exit.\n"
         "# All lines with a leading '#' are discarded and will not\n"
         "# appear in your comment.\n"
-        "# COMMENT IN : %s/%s #%d\n",
-        info->owner, info->repo, info->issue);
+        "# COMMENT IN : %s/%s %s #%d\n",
+        info->owner, info->repo, target_type, info->target_id);
 }
 
 static sn_sv
@@ -106,7 +124,7 @@ ghcli_comment_submit(ghcli_submit_comment_opts opts)
     fprintf(
         stdout,
         "You will be commenting the following in %s/%s #%d:\n"SV_FMT"\n",
-        opts.owner, opts.repo, opts.issue, SV_ARGS(message));
+        opts.owner, opts.repo, opts.target_id, SV_ARGS(message));
 
     if (!opts.always_yes) {
         if (!sn_yesno("Is this okay?"))

--- a/src/forges.c
+++ b/src/forges.c
@@ -42,6 +42,7 @@
 #include <ghcli/github/repos.h>
 
 #include <ghcli/gitlab/api.h>
+#include <ghcli/gitlab/comments.h>
 #include <ghcli/gitlab/config.h>
 #include <ghcli/gitlab/issues.h>
 #include <ghcli/gitlab/merge_requests.h>
@@ -83,7 +84,7 @@ github_forge_descriptor =
 static ghcli_forge_descriptor
 gitlab_forge_descriptor =
 {
-    /* .perform_submit_comment = gitlab_perform_submit_comment, */
+    .perform_submit_comment = gitlab_perform_submit_comment,
     /* .get_issue_comments     = gitlab_get_issue_comments, */
     /* .get_forks              = gitlab_get_forks, */
     /* .fork_create            = gitlab_fork_create, */

--- a/src/forges.c
+++ b/src/forges.c
@@ -52,7 +52,8 @@ static ghcli_forge_descriptor
 github_forge_descriptor =
 {
     .perform_submit_comment = github_perform_submit_comment,
-    .get_issue_comments     = github_get_issue_comments,
+    .get_issue_comments     = github_get_comments,
+    .get_pull_comments      = github_get_comments,
     .get_forks              = github_get_forks,
     .fork_create            = github_fork_create,
     .get_issues             = github_get_issues,
@@ -85,7 +86,8 @@ static ghcli_forge_descriptor
 gitlab_forge_descriptor =
 {
     .perform_submit_comment = gitlab_perform_submit_comment,
-    /* .get_issue_comments     = gitlab_get_issue_comments, */
+    .get_issue_comments     = gitlab_get_issue_comments,
+    .get_pull_comments     = gitlab_get_mr_comments,
     /* .get_forks              = gitlab_get_forks, */
     /* .fork_create            = gitlab_fork_create, */
     .get_issues             = gitlab_get_issues,

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -451,7 +451,7 @@ subcommand_pulls(int argc, char *argv[])
         else if (strcmp(operation, "summary") == 0)
             ghcli_pr_summary(stdout, owner, repo, pr);
         else if (strcmp(operation, "comments") == 0)
-            ghcli_issue_comments(stdout, owner, repo, pr);
+            ghcli_pull_comments(stdout, owner, repo, pr);
         else if (strcmp(operation, "merge") == 0)
             ghcli_pr_merge(stdout, owner, repo, pr);
         else if (strcmp(operation, "close") == 0)

--- a/src/ghcli.c
+++ b/src/ghcli.c
@@ -260,9 +260,10 @@ subcommand_pull_create(int argc, char *argv[])
 static int
 subcommand_comment(int argc, char *argv[])
 {
-    int         ch, issue  = -1;
-    const char *repo       = NULL, *owner = NULL;
-    bool        always_yes = false;
+    int                       ch, target_id  = -1;
+    const char               *repo       = NULL, *owner = NULL;
+    bool                      always_yes = false;
+    enum comment_target_type  target_type;
 
     const struct option options[] = {
         { .name    = "yes",
@@ -297,9 +298,13 @@ subcommand_comment(int argc, char *argv[])
             owner = optarg;
             break;
         case 'p':
-        case 'i': {
+            target_type = PR_COMMENT;
+            goto parse_target_id;
+        case 'i':
+            target_type = ISSUE_COMMENT;
+        parse_target_id: {
             char *endptr;
-            issue = strtoul(optarg, &endptr, 10);
+            target_id = strtoul(optarg, &endptr, 10);
             if (endptr != optarg + strlen(optarg))
                 err(1, "error: Cannot parse issue/PR number");
         } break;
@@ -316,14 +321,15 @@ subcommand_comment(int argc, char *argv[])
 
     check_owner_and_repo(&owner, &repo);
 
-    if (issue < 0)
-        errx(1, "error: missing issue/PR number (use -i)");
+    if (target_id < 0)
+        errx(1, "error: missing issue/PR number (use -i/-p)");
 
     ghcli_comment_submit((ghcli_submit_comment_opts) {
-            .owner      = owner,
-            .repo       = repo,
-            .issue      = issue,
-            .always_yes = always_yes,
+            .owner       = owner,
+            .repo        = repo,
+            .target_type = target_type,
+            .target_id   = target_id,
+            .always_yes  = always_yes,
     });
 
     return EXIT_SUCCESS;

--- a/src/github/comments.c
+++ b/src/github/comments.c
@@ -88,7 +88,7 @@ github_perform_submit_comment(
 }
 
 static int
-github_get_comments(const char *url, ghcli_comment **comments)
+github_perform_get_comments(const char *url, ghcli_comment **comments)
 {
     int                count       = 0;
     json_stream        stream      = {0};
@@ -117,7 +117,7 @@ github_get_comments(const char *url, ghcli_comment **comments)
 }
 
 int
-github_get_issue_comments(
+github_get_comments(
     const char     *owner,
     const char     *repo,
     int             issue,
@@ -127,7 +127,7 @@ github_get_issue_comments(
         "%s/repos/%s/%s/issues/%d/comments",
         github_get_apibase(),
         owner, repo, issue);
-    int n = github_get_comments(url, out);
+    int n = github_perform_get_comments(url, out);
     free((void *)url);
     return n;
 }

--- a/src/github/comments.c
+++ b/src/github/comments.c
@@ -80,7 +80,7 @@ github_perform_submit_comment(
     char *url         = sn_asprintf(
         "%s/repos/%s/%s/issues/%d/comments",
         github_get_apibase(),
-        opts.owner, opts.repo, opts.issue);
+        opts.owner, opts.repo, opts.target_id);
 
     ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
     free(post_fields);

--- a/src/gitlab/comments.c
+++ b/src/gitlab/comments.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ghcli/gitlab/comments.h>
+#include <ghcli/gitlab/config.h>
+
+void
+gitlab_perform_submit_comment(
+    ghcli_submit_comment_opts  opts,
+    ghcli_fetch_buffer        *out)
+{
+    const char *type  = NULL;
+
+    switch (opts.target_type) {
+    case ISSUE_COMMENT:
+        type = "issues";
+        break;
+    case PR_COMMENT:
+        type = "merge_requests";
+        break;
+    }
+
+    char *post_fields = sn_asprintf(
+        "{ \"body\": \""SV_FMT"\" }",
+        SV_ARGS(opts.message));
+    char *url         = sn_asprintf(
+        "%s/projects/%s%%2F%s/%s/%d/notes",
+        gitlab_get_apibase(),
+        opts.owner, opts.repo, type, opts.target_id);
+
+    ghcli_fetch_with_method("POST", url, post_fields, NULL, out);
+    free(post_fields);
+    free(url);
+}


### PR DESCRIPTION
Implements comments (notes in gitlab speak) for both issues and merge requests.

Fixes #57
