### PR TITLE
refactor reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@
 /include/ghcli/gitlab/releases.h~
 /src/gitlab/releases.c~
 /src/gitlab/releases.o
+/include/ghcli/github/review.h~
+/include/ghcli/gitlab/review.h~
+/src/github/review.c~
+/src/github/review.o
+/src/github/reviews.c~
+/src/gitlab/review.c~
+/src/gitlab/review.o

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ghcli_SRCS			=	src/comments.c			\
 					src/github/pulls.c		\
 					src/github/releases.c		\
 					src/github/repos.c		\
+					src/github/review.c		\
 					src/gitlab/api.c		\
 					src/gitlab/comments.c		\
 					src/gitlab/config.c		\
@@ -41,6 +42,7 @@ ghcli_SRCS			=	src/comments.c			\
 					src/gitlab/merge_requests.c	\
 					src/gitlab/repos.c		\
 					src/gitlab/releases.c		\
+					src/gitlab/review.c		\
 					src/issues.c			\
 					src/json_util.c			\
 					src/pulls.c			\

--- a/docs/ghcli-pulls.1
+++ b/docs/ghcli-pulls.1
@@ -90,6 +90,8 @@ Close the PR.
 Reopen a closed PR.
 .It Cm merge
 Merge the PR.
+.It Cm reviews
+Print reviews including comments under them.
 .El
 .Sh EXAMPLES
 Print a list of open PRs in the current project:

--- a/docs/ghcli.1
+++ b/docs/ghcli.1
@@ -69,9 +69,6 @@ Manage your own or other repositories. See
 .It Cm comment
 Submit comments under issues and PRs. See
 .Xr ghcli-comment 1 .
-.It Cm reviews
-Inspect PR reviews. This subcommand is not mature and therefore
-currently undocumented.
 .It Cm version
 Print version and exit.
 .El

--- a/include/ghcli/forges.h
+++ b/include/ghcli/forges.h
@@ -37,6 +37,7 @@
 #include <ghcli/pulls.h>
 #include <ghcli/releases.h>
 #include <ghcli/repos.h>
+#include <ghcli/review.h>
 
 typedef struct ghcli_forge_descriptor ghcli_forge_descriptor;
 
@@ -217,6 +218,14 @@ struct ghcli_forge_descriptor {
     void (*repo_delete)(
         const char *owner,
         const char *repo);
+
+    /**
+     * Fetch MR/PR reviews including comments */
+    size_t (*get_reviews)(
+        const char       *owner,
+        const char       *repo,
+        int               pr,
+        ghcli_pr_review **out);
 
     /**
      * Get an the http authentication header for use by curl */

--- a/include/ghcli/github/review.h
+++ b/include/ghcli/github/review.h
@@ -27,56 +27,15 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef REVIEW_H
-#define REVIEW_H
+#ifndef GITHUB_REVIEW_H
+#define GITHUB_REVIEW_H
 
-#include <sn/sn.h>
+#include <ghcli/review.h>
 
-typedef struct ghcli_pr_review         ghcli_pr_review;
-typedef struct ghcli_pr_review_comment ghcli_pr_review_comment;
-
-struct ghcli_pr_review_comment {
-    char *id;
-    char *author;
-    char *date;
-    char *diff;
-    char *path;
-    char *body;
-    int   original_position;
-};
-
-struct ghcli_pr_review {
-    char                    *id;
-    char                    *author;
-    char                    *date;
-    char                    *state;
-    char                    *body;
-    ghcli_pr_review_comment *comments;
-    size_t                   comments_size;
-};
-
-void ghcli_review_reviews_free(
-    ghcli_pr_review *it,
-    size_t size);
-
-void ghcli_review_comments_free(
-    ghcli_pr_review_comment *it,
-    size_t size);
-
-size_t ghcli_review_get_reviews(
-    const char *owner,
-    const char *repo,
-    int pr,
+size_t github_review_get_reviews(
+    const char       *owner,
+    const char       *repo,
+    int               pr,
     ghcli_pr_review **out);
 
-void ghcli_review_print_review_table(
-    FILE *,
-    ghcli_pr_review *,
-    size_t);
-
-void ghcli_review_print_comments(
-    FILE *out,
-    ghcli_pr_review_comment *comments,
-    size_t comments_size);
-
-#endif /* REVIEW_H */
+#endif /* GITHUB_REVIEW_H */

--- a/include/ghcli/gitlab/review.h
+++ b/include/ghcli/gitlab/review.h
@@ -27,56 +27,15 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef REVIEW_H
-#define REVIEW_H
+#ifndef GITLAB_REVIEW_H
+#define GITLAB_REVIEW_H
 
-#include <sn/sn.h>
+#include <ghcli/review.h>
 
-typedef struct ghcli_pr_review         ghcli_pr_review;
-typedef struct ghcli_pr_review_comment ghcli_pr_review_comment;
-
-struct ghcli_pr_review_comment {
-    char *id;
-    char *author;
-    char *date;
-    char *diff;
-    char *path;
-    char *body;
-    int   original_position;
-};
-
-struct ghcli_pr_review {
-    char                    *id;
-    char                    *author;
-    char                    *date;
-    char                    *state;
-    char                    *body;
-    ghcli_pr_review_comment *comments;
-    size_t                   comments_size;
-};
-
-void ghcli_review_reviews_free(
-    ghcli_pr_review *it,
-    size_t size);
-
-void ghcli_review_comments_free(
-    ghcli_pr_review_comment *it,
-    size_t size);
-
-size_t ghcli_review_get_reviews(
-    const char *owner,
-    const char *repo,
-    int pr,
+size_t gitlab_review_get_reviews(
+    const char       *owner,
+    const char       *repo,
+    int               pr,
     ghcli_pr_review **out);
 
-void ghcli_review_print_review_table(
-    FILE *,
-    ghcli_pr_review *,
-    size_t);
-
-void ghcli_review_print_comments(
-    FILE *out,
-    ghcli_pr_review_comment *comments,
-    size_t comments_size);
-
-#endif /* REVIEW_H */
+#endif /* GITLAB_REVIEW_H */

--- a/include/ghcli/json_util.h
+++ b/include/ghcli/json_util.h
@@ -53,7 +53,7 @@ sn_sv       ghcli_json_escape(sn_sv);
 void        ghcli_print_html_url(ghcli_fetch_buffer);
 size_t      ghcli_read_label_list(json_stream *, sn_sv **);
 size_t      ghcli_read_user_list(json_stream *input, sn_sv **out);
-
+void        ghcli_json_advance(json_stream *input, const char *fmt, ...);
 
 static inline sn_sv
 get_user_sv(json_stream *input)

--- a/include/ghcli/review.h
+++ b/include/ghcli/review.h
@@ -36,7 +36,7 @@ typedef struct ghcli_pr_review         ghcli_pr_review;
 typedef struct ghcli_pr_review_comment ghcli_pr_review_comment;
 
 struct ghcli_pr_review {
-    int   id;
+    char *id;
     char *author;
     char *date;
     char *state;

--- a/include/ghcli/review.h
+++ b/include/ghcli/review.h
@@ -35,16 +35,8 @@
 typedef struct ghcli_pr_review         ghcli_pr_review;
 typedef struct ghcli_pr_review_comment ghcli_pr_review_comment;
 
-struct ghcli_pr_review {
-    char *id;
-    char *author;
-    char *date;
-    char *state;
-    char *body;
-};
-
 struct ghcli_pr_review_comment {
-    int   id;
+    char *id;
     char *author;
     char *date;
     char *diff;
@@ -53,27 +45,42 @@ struct ghcli_pr_review_comment {
     int   original_position;
 };
 
+struct ghcli_pr_review {
+    char                    *id;
+    char                    *author;
+    char                    *date;
+    char                    *state;
+    char                    *body;
+    ghcli_pr_review_comment *comments;
+    size_t                   comments_size;
+};
+
 void ghcli_review_reviews_free(
     ghcli_pr_review *it,
     size_t size);
+
 void ghcli_review_comments_free(
     ghcli_pr_review_comment *it,
     size_t size);
+
 size_t ghcli_review_get_reviews(
     const char *owner,
     const char *repo,
     int pr,
     ghcli_pr_review **out);
+
 size_t ghcli_review_get_review_comments(
     const char *owner,
     const char *repo,
     int pr,
     int review_id,
     ghcli_pr_review_comment **out);
+
 void ghcli_review_print_review_table(
     FILE *,
     ghcli_pr_review *,
     size_t);
+
 void ghcli_review_print_comments(
     FILE *out,
     ghcli_pr_review_comment *comments,

--- a/src/forges.c
+++ b/src/forges.c
@@ -40,6 +40,7 @@
 #include <ghcli/github/pulls.h>
 #include <ghcli/github/releases.h>
 #include <ghcli/github/repos.h>
+#include <ghcli/github/review.h>
 
 #include <ghcli/gitlab/api.h>
 #include <ghcli/gitlab/comments.h>
@@ -49,6 +50,7 @@
 #include <ghcli/gitlab/merge_requests.h>
 #include <ghcli/gitlab/releases.h>
 #include <ghcli/gitlab/repos.h>
+#include <ghcli/gitlab/review.h>
 
 static ghcli_forge_descriptor
 github_forge_descriptor =
@@ -76,6 +78,7 @@ github_forge_descriptor =
     .delete_release         = github_delete_release,
     .get_repos              = github_get_repos,
     .get_own_repos          = github_get_own_repos,
+    .get_reviews            = github_review_get_reviews,
     .repo_delete            = github_repo_delete,
     .get_authheader         = github_get_authheader,
     .get_account            = github_get_account,
@@ -110,6 +113,7 @@ gitlab_forge_descriptor =
     .delete_release         = gitlab_delete_release,
     .get_repos              = gitlab_get_repos,
     .get_own_repos          = gitlab_get_own_repos,
+    .get_reviews            = gitlab_review_get_reviews,
     .repo_delete            = gitlab_repo_delete,
     .get_authheader         = gitlab_get_authheader,
     .get_account            = gitlab_get_account,

--- a/src/github/review.c
+++ b/src/github/review.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2021 Nico Sonack <nsonack@outlook.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ghcli/github/review.h>
+#include <ghcli/github/config.h>
+#include <ghcli/json_util.h>
+
+#include <pdjson/pdjson.h>
+
+static void
+github_parse_review_comment(json_stream *stream, ghcli_pr_review_comment *it)
+{
+    if (json_next(stream) != JSON_OBJECT)
+        errx(1, "Expected review comment object");
+
+    enum json_type key_type;
+    while ((key_type = json_next(stream)) == JSON_STRING) {
+        size_t          len        = 0;
+        const char     *key        = json_get_string(stream, &len);
+        enum json_type  value_type = 0;
+
+        if (strncmp("bodyText", key, len) == 0)
+            it->body = get_string(stream);
+        else if (strncmp("id", key, len) == 0)
+            it->id = get_string(stream);
+        else if (strncmp("createdAt", key, len) == 0)
+            it->date = get_string(stream);
+        else if (strncmp("author", key, len) == 0)
+            it->author = get_user(stream);
+        else if (strncmp("diffHunk", key, len) == 0)
+            it->diff = get_string(stream);
+        else if (strncmp("path", key, len) == 0)
+            it->path = get_string(stream);
+        else if (strncmp("originalPosition", key, len) == 0)
+            it->original_position = get_int(stream);
+        else {
+            value_type = json_next(stream);
+
+            switch (value_type) {
+            case JSON_ARRAY:
+                json_skip_until(stream, JSON_ARRAY_END);
+                break;
+            case JSON_OBJECT:
+                json_skip_until(stream, JSON_OBJECT_END);
+                break;
+            default:
+                break;
+            }
+        }
+    }
+}
+
+static void
+github_parse_review_comments(json_stream *stream, ghcli_pr_review *it)
+{
+    ghcli_json_advance(stream, "{s[", "nodes");
+    while (json_peek(stream) == JSON_OBJECT) {
+        it->comments = realloc(
+            it->comments,
+            sizeof(*it->comments) * (it->comments_size + 1));
+        ghcli_pr_review_comment *comment = &it->comments[it->comments_size++];
+        *comment                         = (ghcli_pr_review_comment) {0};
+        github_parse_review_comment(stream, comment);
+    }
+    ghcli_json_advance(stream, "]}");
+}
+
+static void
+github_parse_review_header(json_stream *stream, ghcli_pr_review *it)
+{
+    if (json_next(stream) != JSON_OBJECT)
+        errx(1, "Expected review object");
+
+    enum json_type key_type;
+    while ((key_type = json_next(stream)) == JSON_STRING) {
+        size_t          len        = 0;
+        const char     *key        = json_get_string(stream, &len);
+        enum json_type  value_type = 0;
+
+        if (strncmp("bodyText", key, len) == 0)
+            it->body = get_string(stream);
+        else if (strncmp("state", key, len) == 0)
+            it->state = get_string(stream);
+        else if (strncmp("id", key, len) == 0)
+            it->id = get_string(stream);
+        else if (strncmp("createdAt", key, len) == 0)
+            it->date = get_string(stream);
+        else if (strncmp("author", key, len) == 0)
+            it->author = get_user(stream);
+        else if (strncmp("comments", key, len) == 0) {
+            github_parse_review_comments(stream, it);
+        } else {
+            value_type = json_next(stream);
+
+            switch (value_type) {
+            case JSON_ARRAY:
+                json_skip_until(stream, JSON_ARRAY_END);
+                break;
+            case JSON_OBJECT:
+                json_skip_until(stream, JSON_OBJECT_END);
+                break;
+            default:
+                break;
+            }
+        }
+    }
+}
+
+static const char *get_reviews_fmt =
+    "query {"
+    "  repository(owner: \"%s\", name: \"%s\") {"
+    "    pullRequest(number: %d) {"
+    "      reviews(first: 10) {"
+    "        nodes {"
+    "          author {"
+    "            login"
+    "          }"
+    "          bodyText"
+    "          id"
+    "          createdAt"
+    "          state"
+    "          comments(first: 10) {"
+    "            nodes {"
+    "              bodyText"
+    "              diffHunk"
+    "              path"
+    "              originalPosition"
+    "              author {"
+    "                login"
+    "              }"
+    "              state"
+    "              createdAt"
+    "              id"
+    "            }"
+    "          }"
+    "        }"
+    "      }"
+    "    }"
+    "  }"
+    "}";
+
+size_t
+github_review_get_reviews(
+    const char *owner,
+    const char *repo,
+    int pr,
+    ghcli_pr_review **out)
+{
+    ghcli_fetch_buffer  buffer        = {0};
+    char               *url           = NULL;
+    char               *query         = NULL;
+    sn_sv               query_escaped = {0};
+    char               *post_data     = NULL;
+    struct json_stream  stream        = {0};
+    enum   json_type    next          = JSON_NULL;
+    size_t              size          = 0;
+
+    url           = sn_asprintf("%s/graphql", github_get_apibase());
+    query         = sn_asprintf(get_reviews_fmt, owner, repo, pr);
+    query_escaped = ghcli_json_escape(SV(query));
+    post_data     = sn_asprintf("{\"query\": \""SV_FMT"\"}",
+                                SV_ARGS(query_escaped));
+    ghcli_fetch_with_method("POST", url, post_data, NULL, &buffer);
+
+    json_open_buffer(&stream, buffer.data, buffer.length);
+    json_set_streaming(&stream, true);
+
+    ghcli_json_advance(
+        &stream, "{s{s{s{s{s",
+        "data", "repository", "pullRequest", "reviews", "nodes");
+
+    next = json_next(&stream);
+    if (next != JSON_ARRAY)
+        errx(1, "error: expected json array for review list");
+
+    while ((next = json_peek(&stream)) == JSON_OBJECT) {
+        *out = realloc(*out, sizeof(ghcli_pr_review) * (size + 1));
+        ghcli_pr_review *it = &(*out)[size];
+
+        *it = (ghcli_pr_review) {0};
+
+        github_parse_review_header(&stream, it);
+
+        size++;
+    }
+
+    if (json_next(&stream) != JSON_ARRAY_END)
+        errx(1, "error: expected end of json array");
+
+    ghcli_json_advance(&stream, "}}}}}");
+
+    free(buffer.data);
+    free(url);
+    free(query);
+    free(query_escaped.data);
+    free(post_data);
+    json_close(&stream);
+
+    return size;
+}

--- a/src/gitlab/review.c
+++ b/src/gitlab/review.c
@@ -27,56 +27,23 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef REVIEW_H
-#define REVIEW_H
+#include <ghcli/gitlab/review.h>
 
 #include <sn/sn.h>
 
-typedef struct ghcli_pr_review         ghcli_pr_review;
-typedef struct ghcli_pr_review_comment ghcli_pr_review_comment;
+size_t
+gitlab_review_get_reviews(
+    const char       *owner,
+    const char       *repo,
+    int               pr,
+    ghcli_pr_review **out)
+{
+    (void) owner;
+    (void) repo;
+    (void) pr;
 
-struct ghcli_pr_review_comment {
-    char *id;
-    char *author;
-    char *date;
-    char *diff;
-    char *path;
-    char *body;
-    int   original_position;
-};
+    warnx("Reviews are not yet supported on Gitlab");
+    *out = NULL;
 
-struct ghcli_pr_review {
-    char                    *id;
-    char                    *author;
-    char                    *date;
-    char                    *state;
-    char                    *body;
-    ghcli_pr_review_comment *comments;
-    size_t                   comments_size;
-};
-
-void ghcli_review_reviews_free(
-    ghcli_pr_review *it,
-    size_t size);
-
-void ghcli_review_comments_free(
-    ghcli_pr_review_comment *it,
-    size_t size);
-
-size_t ghcli_review_get_reviews(
-    const char *owner,
-    const char *repo,
-    int pr,
-    ghcli_pr_review **out);
-
-void ghcli_review_print_review_table(
-    FILE *,
-    ghcli_pr_review *,
-    size_t);
-
-void ghcli_review_print_comments(
-    FILE *out,
-    ghcli_pr_review_comment *comments,
-    size_t comments_size);
-
-#endif /* REVIEW_H */
+    return 0;
+}

--- a/src/review.c
+++ b/src/review.c
@@ -257,9 +257,9 @@ ghcli_review_print_review_table(
 
 void
 ghcli_review_print_comments(
-    FILE *out,
+    FILE                    *out,
     ghcli_pr_review_comment *comments,
-    size_t comments_size)
+    size_t                   comments_size)
 {
     for (size_t i = 0; i < comments_size; ++i) {
         fprintf(out,

--- a/src/review.c
+++ b/src/review.c
@@ -88,6 +88,9 @@ ghcli_review_print_comments(
 void
 ghcli_review_reviews_free(ghcli_pr_review *it, size_t size)
 {
+    if (!it)
+        return;
+
     for (size_t i = 0; i < size; ++i) {
         free(it[i].author);
         free(it[i].date);
@@ -104,6 +107,9 @@ ghcli_review_reviews_free(ghcli_pr_review *it, size_t size)
 void
 ghcli_review_comments_free(ghcli_pr_review_comment *it, size_t size)
 {
+    if (!it)
+        return;
+
     for (size_t i = 0; i < size; ++i) {
         free(it[i].id);
         free(it[i].author);

--- a/src/review.c
+++ b/src/review.c
@@ -29,6 +29,7 @@
 
 #include <ghcli/config.h>
 #include <ghcli/curl.h>
+#include <ghcli/forges.h>
 #include <ghcli/github/config.h>
 #include <ghcli/json_util.h>
 #include <ghcli/review.h>
@@ -36,198 +37,6 @@
 #include <pdjson/pdjson.h>
 
 #include <limits.h>
-
-static void
-parse_review_comment(json_stream *stream, ghcli_pr_review_comment *it)
-{
-    if (json_next(stream) != JSON_OBJECT)
-        errx(1, "Expected review comment object");
-
-    enum json_type key_type;
-    while ((key_type = json_next(stream)) == JSON_STRING) {
-        size_t          len        = 0;
-        const char     *key        = json_get_string(stream, &len);
-        enum json_type  value_type = 0;
-
-        if (strncmp("bodyText", key, len) == 0)
-            it->body = get_string(stream);
-        else if (strncmp("id", key, len) == 0)
-            it->id = get_string(stream);
-        else if (strncmp("createdAt", key, len) == 0)
-            it->date = get_string(stream);
-        else if (strncmp("author", key, len) == 0)
-            it->author = get_user(stream);
-        else if (strncmp("diffHunk", key, len) == 0)
-            it->diff = get_string(stream);
-        else if (strncmp("path", key, len) == 0)
-            it->path = get_string(stream);
-        else if (strncmp("originalPosition", key, len) == 0)
-            it->original_position = get_int(stream);
-        else {
-            value_type = json_next(stream);
-
-            switch (value_type) {
-            case JSON_ARRAY:
-                json_skip_until(stream, JSON_ARRAY_END);
-                break;
-            case JSON_OBJECT:
-                json_skip_until(stream, JSON_OBJECT_END);
-                break;
-            default:
-                break;
-            }
-        }
-    }
-}
-
-static void
-parse_review_comments(json_stream *stream, ghcli_pr_review *it)
-{
-    ghcli_json_advance(stream, "{s[", "nodes");
-    while (json_peek(stream) == JSON_OBJECT) {
-        it->comments = realloc(
-            it->comments,
-            sizeof(*it->comments) * (it->comments_size + 1));
-        ghcli_pr_review_comment *comment = &it->comments[it->comments_size++];
-        *comment                         = (ghcli_pr_review_comment) {0};
-        parse_review_comment(stream, comment);
-    }
-    ghcli_json_advance(stream, "]}");
-}
-
-static void
-parse_review_header(json_stream *stream, ghcli_pr_review *it)
-{
-    if (json_next(stream) != JSON_OBJECT)
-        errx(1, "Expected review object");
-
-    enum json_type key_type;
-    while ((key_type = json_next(stream)) == JSON_STRING) {
-        size_t          len        = 0;
-        const char     *key        = json_get_string(stream, &len);
-        enum json_type  value_type = 0;
-
-        if (strncmp("bodyText", key, len) == 0)
-            it->body = get_string(stream);
-        else if (strncmp("state", key, len) == 0)
-            it->state = get_string(stream);
-        else if (strncmp("id", key, len) == 0)
-            it->id = get_string(stream);
-        else if (strncmp("createdAt", key, len) == 0)
-            it->date = get_string(stream);
-        else if (strncmp("author", key, len) == 0)
-            it->author = get_user(stream);
-        else if (strncmp("comments", key, len) == 0) {
-            parse_review_comments(stream, it);
-        } else {
-            value_type = json_next(stream);
-
-            switch (value_type) {
-            case JSON_ARRAY:
-                json_skip_until(stream, JSON_ARRAY_END);
-                break;
-            case JSON_OBJECT:
-                json_skip_until(stream, JSON_OBJECT_END);
-                break;
-            default:
-                break;
-            }
-        }
-    }
-}
-
-static const char *get_reviews_fmt =
-    "query {"
-    "  repository(owner: \"%s\", name: \"%s\") {"
-    "    pullRequest(number: %d) {"
-    "      reviews(first: 10) {"
-    "        nodes {"
-    "          author {"
-    "            login"
-    "          }"
-    "          bodyText"
-    "          id"
-    "          createdAt"
-    "          state"
-    "          comments(first: 10) {"
-    "            nodes {"
-    "              bodyText"
-    "              diffHunk"
-    "              path"
-    "              originalPosition"
-    "              author {"
-    "                login"
-    "              }"
-    "              state"
-    "              createdAt"
-    "              id"
-    "            }"
-    "          }"
-    "        }"
-    "      }"
-    "    }"
-    "  }"
-    "}";
-
-size_t
-ghcli_review_get_reviews(
-    const char *owner,
-    const char *repo,
-    int pr,
-    ghcli_pr_review **out)
-{
-    ghcli_fetch_buffer  buffer        = {0};
-    char               *url           = NULL;
-    char               *query         = NULL;
-    sn_sv               query_escaped = {0};
-    char               *post_data     = NULL;
-    struct json_stream  stream        = {0};
-    enum   json_type    next          = JSON_NULL;
-    size_t              size          = 0;
-
-    url           = sn_asprintf("%s/graphql", github_get_apibase());
-    query         = sn_asprintf(get_reviews_fmt, owner, repo, pr);
-    query_escaped = ghcli_json_escape(SV(query));
-    post_data     = sn_asprintf("{\"query\": \""SV_FMT"\"}",
-                                SV_ARGS(query_escaped));
-    ghcli_fetch_with_method("POST", url, post_data, NULL, &buffer);
-
-    json_open_buffer(&stream, buffer.data, buffer.length);
-    json_set_streaming(&stream, true);
-
-    ghcli_json_advance(
-        &stream, "{s{s{s{s{s",
-        "data", "repository", "pullRequest", "reviews", "nodes");
-
-    next = json_next(&stream);
-    if (next != JSON_ARRAY)
-        errx(1, "error: expected json array for review list");
-
-    while ((next = json_peek(&stream)) == JSON_OBJECT) {
-        *out = realloc(*out, sizeof(ghcli_pr_review) * (size + 1));
-        ghcli_pr_review *it = &(*out)[size];
-
-        *it = (ghcli_pr_review) {0};
-
-        parse_review_header(&stream, it);
-
-        size++;
-    }
-
-    if (json_next(&stream) != JSON_ARRAY_END)
-        errx(1, "error: expected end of json array");
-
-    ghcli_json_advance(&stream, "}}}}}");
-
-    free(buffer.data);
-    free(url);
-    free(query);
-    free(query_escaped.data);
-    free(post_data);
-    json_close(&stream);
-
-    return size;
-}
 
 void
 ghcli_review_print_review_table(
@@ -307,49 +116,11 @@ ghcli_review_comments_free(ghcli_pr_review_comment *it, size_t size)
     free(it);
 }
 
-size_t
-ghcli_review_get_review_comments(
-    const char               *owner,
-    const char               *repo,
-    int                       pr,
-    int                       review_id,
-    ghcli_pr_review_comment **out)
+size_t ghcli_review_get_reviews(
+    const char       *owner,
+    const char       *repo,
+    int               pr,
+    ghcli_pr_review **out)
 {
-    char               *url    = NULL;
-    ghcli_fetch_buffer  buffer = {0};
-    struct json_stream  stream = {0};
-    enum json_type      next   = JSON_NULL;
-    size_t              size   = 0;
-
-    url = sn_asprintf(
-        "%s/repos/%s/%s/pulls/%d/reviews/%d/comments",
-        github_get_apibase(),
-        owner, repo, pr, review_id);
-    ghcli_fetch(url, NULL, &buffer);
-
-    json_open_buffer(&stream, buffer.data, buffer.length);
-    json_set_streaming(&stream, true);
-
-    next = json_next(&stream);
-    if (next != JSON_ARRAY)
-        errx(1, "error: expected json array for review comment list");
-
-    while ((next = json_peek(&stream)) == JSON_OBJECT) {
-        *out = realloc(*out, sizeof(ghcli_pr_review_comment) * (size + 1));
-
-        /* Make sure, that we don't have garbarge uninitialized string
-         * pointers in here */
-        (*out)[size] = (ghcli_pr_review_comment) {0};
-        parse_review_comment(&stream, &(*out)[size]);
-        size++;
-    }
-
-    if (json_next(&stream) != JSON_ARRAY_END)
-        errx(1, "error: expected end of json array");
-
-    free(buffer.data);
-    free(url);
-    json_close(&stream);
-
-    return size;
+    return ghcli_forge()->get_reviews(owner, repo, pr, out);
 }


### PR DESCRIPTION
Removed the undocumented reviews subcommand.
Added a pulls action to fetch reviews.

Now using the graphql endpoint of the github api to fetch the data for github.

Currently not implemented on gitlab. (See #76)
