### PR TITLE
(#90) Choose correct override account from the command line argument

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -95,17 +95,12 @@ ${PROGS:=-install}:
 	install -d ${BINDIR}
 	install ${@:-install=} ${BINDIR}
 
-${LIBS:=-install}:
-	@echo " ==> Installing library {@:-install=}"
-	install -d ${LIBDIR}
-	install ${@:-install=} ${LIBDIR}
-
 ${MAN:=-install}:
 	@echo " ==> Installing man page ${@:-install=}"
 	install -d ${MANDIR}/man`echo "${@:-install=}" | sed 's/.*\.\([1-9]\)$$/\1/g'`
 	gzip -c ${@:-install=} > ${MANDIR}/man`echo "${@:-install=}" | sed 's/.*\.\([1-9]\)$$/\1/g'`/`basename ${@:-install=}`.gz
 
-install: all ${PROGS:=-install} ${LIBS:=-install} ${MAN:=-install}
+install: all ${PROGS:=-install} ${MAN:=-install}
 	@echo " ==> Installation finished"
 
 snmk-libdeps:

--- a/include/ghcli/config.h
+++ b/include/ghcli/config.h
@@ -52,5 +52,6 @@ sn_sv             ghcli_config_get_account(void);
 sn_sv             ghcli_config_get_upstream(void);
 sn_sv             ghcli_config_get_base(void);
 ghcli_forge_type  ghcli_config_get_forge_type(void);
+sn_sv             ghcli_config_get_override_default_account(void);
 
 #endif /* CONFIG_H */

--- a/src/config.c
+++ b/src/config.c
@@ -500,6 +500,14 @@ ghcli_config_get_base(void)
     return ghcli_local_config_find_by_key("pr.base");
 }
 
+sn_sv
+ghcli_config_get_override_default_account(void)
+{
+    init_local_config();
+
+    return SV((char *)config.override_default_account);
+}
+
 ghcli_forge_type
 ghcli_config_get_forge_type(void)
 {

--- a/src/config.c
+++ b/src/config.c
@@ -505,7 +505,10 @@ ghcli_config_get_override_default_account(void)
 {
     init_local_config();
 
-    return SV((char *)config.override_default_account);
+    if (config.override_default_account)
+        return SV((char *)config.override_default_account);
+    else
+        return SV_NULL;
 }
 
 ghcli_forge_type

--- a/src/github/config.c
+++ b/src/github/config.c
@@ -34,12 +34,18 @@
 static sn_sv
 github_default_account_name(void)
 {
-    sn_sv section_name = ghcli_config_find_by_key(
-        SV("defaults"),
-        "github-default-account");
+    sn_sv section_name;
 
-    if (sn_sv_null(section_name))
-        errx(1, "Config file does not name a default GitHub account name.");
+    section_name = ghcli_config_get_override_default_account();
+
+    if (sn_sv_null(section_name)) {
+        section_name = ghcli_config_find_by_key(
+            SV("defaults"),
+            "github-default-account");
+
+        if (sn_sv_null(section_name))
+            errx(1, "Config file does not name a default GitHub account name.");
+    }
 
     return section_name;
 }

--- a/src/gitlab/config.c
+++ b/src/gitlab/config.c
@@ -35,12 +35,21 @@
 static sn_sv
 gitlab_default_account_name(void)
 {
-    sn_sv section_name = ghcli_config_find_by_key(
-        SV("defaults"),
-        "gitlab-default-account");
+    sn_sv section_name;
 
-    if (sn_sv_null(section_name))
-        errx(1, "Config file does not name a default GitLab account name.");
+    /* Use default override account */
+    section_name = ghcli_config_get_override_default_account();
+
+    /* If not manually overridden */
+    if (sn_sv_null(section_name)) {
+        section_name = ghcli_config_find_by_key(
+            SV("defaults"),
+            "gitlab-default-account");
+
+        /* Welp, no luck here */
+        if (sn_sv_null(section_name))
+            errx(1, "Config file does not name a default GitLab account name.");
+    }
 
     return section_name;
 }


### PR DESCRIPTION

Before we used to always choose the wrong default account based on the forge type of the override account.
Now we check whether we have an override account and then retrieve its name to continue.

Also, I removed the libinstall code from default.mk as it resulted in buggy installs of libghcli.a. We don't need to install it.
