### PR TITLE
(#93) (#95) Add support for Gitlab in the status subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,15 +65,16 @@ LIBADD				=	libcurl
 
 # Leave this undefined if you don't have any manpages that need to be
 # installed.
-MAN				=	docs/ghcli.1 \
-					docs/ghcli-repos.1 \
-					docs/ghcli-forks.1 \
-					docs/ghcli-releases.1 \
-					docs/ghcli-issues.1 \
-					docs/ghcli-pulls.1 \
-					docs/ghcli-comment.1 \
-					docs/ghcli-gists.1 \
-					docs/ghcli-snippets.1
+MAN				=	docs/ghcli.1		\
+					docs/ghcli-repos.1	\
+					docs/ghcli-forks.1	\
+					docs/ghcli-releases.1	\
+					docs/ghcli-issues.1	\
+					docs/ghcli-pulls.1	\
+					docs/ghcli-comment.1	\
+					docs/ghcli-gists.1	\
+					docs/ghcli-snippets.1	\
+					docs/ghcli-status.1
 
 # Include the rules to build your program
 # Important: the autodetect.sh script needs to be in place

--- a/docs/ghcli-status.1
+++ b/docs/ghcli-status.1
@@ -1,0 +1,27 @@
+.Dd $Mdocdate$
+.Dt GHCLI-STATUS 1
+.Os
+.Sh NAME
+.Nm ghcli status
+.Nd Print a list of notifications and/or TODOs
+.Sh SYNOPSIS
+.Nm
+.Sh DESCRIPTION
+.Nm
+prints a list of TODOs and notifications on the given account.
+.Sh OPTIONS
+None.
+.Sh EXAMPLES
+Print a TODO list for my-account:
+.Bd -literal -offset indent
+$ ghcli -a my-account status
+.Ed
+
+.Sh SEE ALSO
+.Xr ghcli 1 ,
+.Xr ghcli-issues 1 ,
+.Xr ghcli-pulls 1
+.Sh AUTHORS
+.An Nico Sonack aka. herrhotzenplotz Aq Mt nsonack@outlook.com
+.Sh BUGS
+Please report issues preferably via e-mail or on GitHub.

--- a/docs/ghcli.1
+++ b/docs/ghcli.1
@@ -36,6 +36,9 @@
 .Cm comment Op Ar options
 .Nm
 .Cm version
+.Nm
+.Op Fl a Ar override-account
+.Cm status
 .Sh DESCRIPTION
 .Nm
 can be used to interact with both GitHub and GitLab from the command
@@ -76,6 +79,9 @@ Submit comments under issues and PRs. See
 .Xr ghcli-comment 1 .
 .It Cm version
 Print version and exit.
+.It Cm status
+Print a list of TODOs and/or notifications. See
+.Xr ghcli-status 1 .
 .El
 .Sh OPTIONS
 .Bl -tag -width indent


### PR DESCRIPTION
Fixes #93
Fixes #95

Adds the ghcli-status(1) man page and support for Gitlab to that subcommand.
