### PR TITLE
Build shared library on cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ bin_PROGRAMS = gcli$(EXEEXT)
 gcli_LDADD = libgcli.la
 
 libgcli_la_LIBADD = libpdjson.la libsn.la
+libgcli_la_LDFLAGS = -no-undefined
 
 dist_man_MANS = \
 	docs/gcli-api.1 \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-1.x86_64 2024-02-01 11:02 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/herrhotzenplotz/gcli.git
$ cd gcli
$ ./autogen.sh
$ ./configure --enable-shared --disable-static
$ make V=1
: 
/bin/sh ./libtool  --tag=CC   --mode=link gcc -Wno-gnu-zero-variadic-macro-arguments -g -O2  -lcurl  -o libgcli.la -rpath /usr/local/lib src/libgcli_la-ctx.lo src/libgcli_la-gcli.lo src/libgcli_la-date_time.lo src/libgcli_la-attachments.lo src/libgcli_la-base64.lo src/libgcli_la-comments.lo src/libgcli_la-curl.lo src/libgcli_la-forges.lo src/libgcli_la-forks.lo src/libgcli_la-issues.lo src/libgcli_la-json_gen.lo src/libgcli_la-json_util.lo src/libgcli_la-labels.lo src/libgcli_la-milestones.lo src/libgcli_la-nvlist.lo src/libgcli_la-pulls.lo src/libgcli_la-releases.lo src/libgcli_la-repos.lo src/gitlab/libgcli_la-snippets.lo src/libgcli_la-status.lo src/libgcli_la-sshkeys.lo src/gitlab/libgcli_la-api.lo src/gitlab/libgcli_la-comments.lo src/gitlab/libgcli_la-config.lo src/gitlab/libgcli_la-forks.lo src/gitlab/libgcli_la-issues.lo src/gitlab/libgcli_la-labels.lo src/gitlab/libgcli_la-merge_requests.lo src/gitlab/libgcli_la-milestones.lo src/gitlab/libgcli_la-pipelines.lo src/gitlab/libgcli_la-releases.lo src/gitlab/libgcli_la-repos.lo src/gitlab/libgcli_la-status.lo src/gitlab/libgcli_la-sshkeys.lo src/github/libgcli_la-releases.lo src/github/libgcli_la-config.lo src/github/libgcli_la-api.lo src/github/libgcli_la-repos.lo src/github/libgcli_la-forks.lo src/github/libgcli_la-pulls.lo src/github/libgcli_la-comments.lo src/github/libgcli_la-status.lo src/github/libgcli_la-labels.lo src/github/libgcli_la-milestones.lo src/github/libgcli_la-issues.lo src/github/libgcli_la-checks.lo src/github/libgcli_la-gists.lo src/github/libgcli_la-sshkeys.lo src/gitea/libgcli_la-issues.lo src/gitea/libgcli_la-labels.lo src/gitea/libgcli_la-forks.lo src/gitea/libgcli_la-comments.lo src/gitea/libgcli_la-config.lo src/gitea/libgcli_la-pulls.lo src/gitea/libgcli_la-releases.lo src/gitea/libgcli_la-repos.lo src/gitea/libgcli_la-sshkeys.lo src/gitea/libgcli_la-status.lo src/gitea/libgcli_la-milestones.lo src/bugzilla/libgcli_la-api.lo src/bugzilla/libgcli_la-attachments.lo src/bugzilla/libgcli_la-bugs.lo src/bugzilla/libgcli_la-bugs-parser.lo src/bugzilla/libgcli_la-config.lo templates/github/libgcli_la-api.lo templates/github/libgcli_la-checks.lo templates/github/libgcli_la-comments.lo templates/github/libgcli_la-forks.lo templates/github/libgcli_la-gists.lo templates/github/libgcli_la-issues.lo templates/github/libgcli_la-labels.lo templates/github/libgcli_la-pulls.lo templates/github/libgcli_la-releases.lo templates/github/libgcli_la-repos.lo templates/github/libgcli_la-status.lo templates/github/libgcli_la-milestones.lo templates/gitlab/libgcli_la-api.lo templates/gitlab/libgcli_la-comments.lo templates/gitlab/libgcli_la-forks.lo templates/gitlab/libgcli_la-issues.lo templates/gitlab/libgcli_la-labels.lo templates/gitlab/libgcli_la-merge_requests.lo templates/gitlab/libgcli_la-milestones.lo templates/gitlab/libgcli_la-pipelines.lo templates/gitlab/libgcli_la-releases.lo templates/gitlab/libgcli_la-repos.lo templates/gitlab/libgcli_la-sshkeys.lo templates/gitlab/libgcli_la-status.lo templates/gitlab/libgcli_la-snippets.lo templates/gitea/libgcli_la-milestones.lo templates/gitea/libgcli_la-status.lo templates/bugzilla/libgcli_la-api.lo templates/bugzilla/libgcli_la-bugs.lo libpdjson.la libsn.la
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!