### PR TITLE
Feat/implement pr approval gitea/matbgn closes #144

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /stamp-h1
 /ylwrap
 /**/*.o
+/**/*.d
 /**/*.lo
 /**/*.la
 /**/*.*~
@@ -49,3 +50,7 @@
 /m4/lt~obsolete.m4
 /libgcli.pc
 build/**
+lex.yy.c
+y.tab.c
+y.tab.h
+docs/gcli-tutorial.1

--- a/Makefile.in
+++ b/Makefile.in
@@ -187,6 +187,7 @@ LIBGCLI_SRCS = \
 	src/gitea/labels.c \
 	src/gitea/milestones.c \
 	src/gitea/pulls.c \
+	src/gitea/review.c \
 	src/gitea/releases.c \
 	src/gitea/repos.c \
 	src/gitea/sshkeys.c \

--- a/include/gcli/gitea/pulls.h
+++ b/include/gcli/gitea/pulls.h
@@ -88,4 +88,12 @@ int gitea_pull_get_reviews(struct gcli_ctx *ctx,
                            struct gcli_path const *path,
                            struct gcli_pull_reviews *out);
 
+int gitea_pull_create_review(struct gcli_ctx *ctx,
+                             struct gcli_pull_create_review_details const *details);
+
+
+int gitea_pull_get_review_url(struct gcli_ctx *ctx,
+                              struct gcli_path const *const path,
+                              char **url);
+
 #endif /* GITEA_PULLS_H */

--- a/include/gcli/gitea/review.h
+++ b/include/gcli/gitea/review.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2025 Nico Sonack <nsonack@herrhotzenplotz.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef GCLI_GITEA_REVIEW_H
+#define GCLI_GITEA_REVIEW_H
+
+#include <gcli/pulls.h>
+
+int gitea_pull_create_review(struct gcli_ctx *ctx,
+                             struct gcli_pull_create_review_details const *details);
+
+#endif /* GCLI_GITEA_REVIEW_H */

--- a/include/gcli/port/util.h
+++ b/include/gcli/port/util.h
@@ -33,6 +33,7 @@
 #include <gcli/port/err.h>
 
 #include <stdbool.h>
+#include <stdio.h>
 
 /* for convenience */
 #define gcli_unimplemented errx(42, "%s: unimplemented", __func__)
@@ -53,6 +54,7 @@ gcli_min(int x, int y)
 }
 
 int gcli_read_file(char const *path, char **buffer);
+int gcli_read_stream(FILE *stream, char **buffer);
 
 /* interactive user functions */
 bool gcli_yesno(const char *fmt, ...) PRINTF_FORMAT(1, 2);

--- a/src/cmd/pulls.c
+++ b/src/cmd/pulls.c
@@ -111,6 +111,8 @@ usage(void)
 		fprintf(stderr, "  discussions            Show a threaded view of review discussions\n");
 	fprintf(stderr, "  approve                Approve this PR\n");
 	fprintf(stderr, "  unapprove              Revoke approval on this PR\n");
+	fprintf(stderr, "OPTIONS FOR approve/unapprove:\n");
+	fprintf(stderr, "  -F file, --file=file   Read the message from the specified file\n");
 
 	fprintf(stderr, "\n");
 	version();
@@ -1517,77 +1519,179 @@ approval_init(struct gcli_ctx *ctx, FILE *f, void *data)
 static int
 action_approve(struct gcli_path const *const path,
                struct gcli_pull const *const pull,
-               int *argc, char **argv[])
+               int *argc_p, char ***argv_p)
 {
- char *message = NULL;
- int rc = 0;
+	char *message = NULL;
+	int rc = 0;
+	char *file_message = NULL;
 
- (void) pull;
- (void) argc;
- (void) argv;
+	(void)pull;
 
- if (gcli_yesno("Enter a message?")) {
-  message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
-  if (!message) {
-   fprintf(stderr, "gcli: empty message, aborting.\n");
-   return GCLI_EX_DATAERR;
-  }
- }
+	/* Parse --file argument */
+	if (*argc_p > 1) {
+		const char *arg = (*argv_p)[1];
+		if (strcmp(arg, "--file") == 0 || strcmp(arg, "-F") == 0) {
+			if (*argc_p < 3) {
+				fprintf(stderr, "gcli: error: --file requires an argument\n");
+				return GCLI_EX_USAGE;
+			}
+			if (strcmp((*argv_p)[2], "-") == 0) {
+				if (gcli_read_stream(stdin, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read from stdin\n");
+					return GCLI_EX_DATAERR;
+				}
+			} else {
+				if (gcli_read_file((*argv_p)[2], &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read file '%s'\n", (*argv_p)[2]);
+					return GCLI_EX_DATAERR;
+				}
+			}
+			*argc_p -= 2;
+			*argv_p += 2;
+		} else if (strncmp(arg, "--file=", 7) == 0) {
+			if (strcmp(arg + 7, "-") == 0) {
+				if (gcli_read_stream(stdin, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read from stdin\n");
+					return GCLI_EX_DATAERR;
+				}
+			} else {
+				if (gcli_read_file(arg + 7, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read file '%s'\n", arg + 7);
+					return GCLI_EX_DATAERR;
+				}
+			}
+			*argc_p -= 1;
+			*argv_p += 1;
+		}
+	}
 
- if (message) {
- 	rc = gcli_pull_approve(g_clictx, path, message);
- } else {
- 	rc = gcli_pull_approve(g_clictx, path, "Approved");
- }
+	/* If we got a message from a file, use it */
+	if (file_message) {
+		message = file_message;
+	} else {
+		/* Otherwise, use the interactive approach */
+		if (gcli_yesno("Enter a message?")) {
+			message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
+			if (!message) {
+				fprintf(stderr, "gcli: empty message, aborting.\n");
+				free(file_message);
+				return GCLI_EX_DATAERR;
+			}
+		}
+	}
 
- if (rc < 0) {
- 	fprintf(stderr, "gcli: error: failed to approve pull request: %s\n",
- 	        gcli_get_error(g_clictx));
- 	return GCLI_EX_DATAERR;
- }
+	if (message) {
+		rc = gcli_pull_approve(g_clictx, path, message);
+	} else {
+		rc = gcli_pull_approve(g_clictx, path, "Approved");
+	}
 
- free(message);
+	if (rc < 0) {
+		fprintf(stderr, "gcli: error: failed to approve pull request: %s\n",
+		        gcli_get_error(g_clictx));
+		free(file_message);
+		if (message && message != file_message) {
+			free(message);
+		}
+		return GCLI_EX_DATAERR;
+	}
 
- return GCLI_EX_OK;
+	free(file_message);
+	if (message && message != file_message) {
+		free(message);
+	}
+
+	return GCLI_EX_OK;
 }
 
 static int
 action_unapprove(struct gcli_path const *const path,
                  struct gcli_pull const *const pull,
-                 int *argc, char **argv[])
+                 int *argc_p, char ***argv_p)
 {
-char *message = NULL;
-int rc = 0;
+	char *message = NULL;
+	int rc = 0;
+	char *file_message = NULL;
 
-(void) pull;
-(void) argc;
-(void) argv;
+	(void)pull;
 
-if (gcli_yesno("Enter a message?")) {
- message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
- if (!message) {
-  fprintf(stderr, "gcli: empty message, aborting.\n");
-  return GCLI_EX_DATAERR;
- }
-}
+	/* Manually parse --file argument */
+	if (*argc_p > 1) {
+		const char *arg = (*argv_p)[1];
+		if (strcmp(arg, "--file") == 0 || strcmp(arg, "-F") == 0) {
+			if (*argc_p < 3) {
+				fprintf(stderr, "gcli: error: --file requires an argument\n");
+				return GCLI_EX_USAGE;
+			}
+			if (strcmp((*argv_p)[2], "-") == 0) {
+				if (gcli_read_stream(stdin, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read from stdin\n");
+					return GCLI_EX_DATAERR;
+				}
+			} else {
+				if (gcli_read_file((*argv_p)[2], &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read file '%s'\n", (*argv_p)[2]);
+					return GCLI_EX_DATAERR;
+				}
+			}
+			*argc_p -= 2;
+			*argv_p += 2;
+		} else if (strncmp(arg, "--file=", 7) == 0) {
+			if (strcmp(arg + 7, "-") == 0) {
+				if (gcli_read_stream(stdin, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read from stdin\n");
+					return GCLI_EX_DATAERR;
+				}
+			} else {
+				if (gcli_read_file(arg + 7, &file_message) < 0) {
+					fprintf(stderr, "gcli: error: failed to read file '%s'\n", arg + 7);
+					return GCLI_EX_DATAERR;
+				}
+			}
+			*argc_p -= 1;
+			*argv_p += 1;
+		}
+	}
 
-if (message) {
- rc = gcli_pull_unapprove(g_clictx, path, message);
-} else {
- rc = gcli_pull_unapprove(g_clictx, path, "Unapproved");
-}
+	/* If we got a message from a file, use it */
+	if (file_message) {
+		message = file_message;
+	} else {
+		/* Otherwise, use the interactive approach */
+		if (gcli_yesno("Enter a message?")) {
+			message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
+			if (!message) {
+				fprintf(stderr, "gcli: empty message, aborting.\n");
+				free(file_message);
+				return GCLI_EX_DATAERR;
+			}
+		}
+	}
 
-if (rc < 0) {
- fprintf(stderr, "gcli: error: failed to unapprove pull request: %s\n",
-         gcli_get_error(g_clictx));
- if (strstr(gcli_get_error(g_clictx), "reject your own pull is not allowed"))
-  fprintf(stderr, "NOTE: Gitea does not allow you to unapprove your own pull requests.\n");
- return GCLI_EX_DATAERR;
-}
+	if (message) {
+		rc = gcli_pull_unapprove(g_clictx, path, message);
+	} else {
+		rc = gcli_pull_unapprove(g_clictx, path, "Unapproved");
+	}
 
-free(message);
+	if (rc < 0) {
+		fprintf(stderr, "gcli: error: failed to unapprove pull request: %s\n",
+		        gcli_get_error(g_clictx));
+		if (strstr(gcli_get_error(g_clictx), "reject your own pull is not allowed"))
+			fprintf(stderr, "NOTE: Gitea does not allow you to unapprove your own pull requests.\n");
+		free(file_message);
+		if (message && message != file_message) {
+			free(message);
+		}
+		return GCLI_EX_DATAERR;
+	}
 
-return GCLI_EX_OK;
+	free(file_message);
+	if (message && message != file_message) {
+		free(message);
+	}
+
+	return GCLI_EX_OK;
 }
 
 struct gcli_cmd_actions gcli_pull_actions = {

--- a/src/cmd/pulls.c
+++ b/src/cmd/pulls.c
@@ -1513,47 +1513,42 @@ approval_init(struct gcli_ctx *ctx, FILE *f, void *data)
 	fprintf(f, "! All lines starting with '!' will be discarded.\n");
 }
 
-static int
-approval_action(struct gcli_path const *const path,
-                int (*fn)(struct gcli_ctx *ctx, struct gcli_path const *, char const *))
-{
-	int rc;
-	char *message = NULL;
-
-	if (gcli_yesno("Enter a message?")) {
-		message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
-
-		if (message == NULL) {
-			fprintf(stderr, "gcli: message empty, aborting.\n");
-			return GCLI_EX_DATAERR;
-		}
-	}
-
-	rc = fn(g_clictx, path, message);
-	if (rc < 0) {
-		fprintf(stderr, "gcli: error: failed to update pull: %s\n",
-		        gcli_get_error(g_clictx));
-
-		rc = GCLI_EX_DATAERR;
-	} else {
-		rc = GCLI_EX_OK;
-	}
-
-	free(message);
-
-	return rc;
-}
 
 static int
 action_approve(struct gcli_path const *const path,
                struct gcli_pull const *const pull,
                int *argc, char **argv[])
 {
-	(void) pull;
-	(void) argc;
-	(void) argv;
+ char *message = NULL;
+ int rc = 0;
 
-	return approval_action(path, gcli_pull_approve);
+ (void) pull;
+ (void) argc;
+ (void) argv;
+
+ if (gcli_yesno("Enter a message?")) {
+  message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
+  if (!message) {
+   fprintf(stderr, "gcli: empty message, aborting.\n");
+   return GCLI_EX_DATAERR;
+  }
+ }
+
+ if (message) {
+ 	rc = gcli_pull_approve(g_clictx, path, message);
+ } else {
+ 	rc = gcli_pull_approve(g_clictx, path, "Approved");
+ }
+
+ if (rc < 0) {
+ 	fprintf(stderr, "gcli: error: failed to approve pull request: %s\n",
+ 	        gcli_get_error(g_clictx));
+ 	return GCLI_EX_DATAERR;
+ }
+
+ free(message);
+
+ return GCLI_EX_OK;
 }
 
 static int
@@ -1561,11 +1556,38 @@ action_unapprove(struct gcli_path const *const path,
                  struct gcli_pull const *const pull,
                  int *argc, char **argv[])
 {
-	(void) pull;
-	(void) argc;
-	(void) argv;
+char *message = NULL;
+int rc = 0;
 
-	return approval_action(path, gcli_pull_unapprove);
+(void) pull;
+(void) argc;
+(void) argv;
+
+if (gcli_yesno("Enter a message?")) {
+ message = gcli_editor_get_user_message(g_clictx, approval_init, NULL);
+ if (!message) {
+  fprintf(stderr, "gcli: empty message, aborting.\n");
+  return GCLI_EX_DATAERR;
+ }
+}
+
+if (message) {
+ rc = gcli_pull_unapprove(g_clictx, path, message);
+} else {
+ rc = gcli_pull_unapprove(g_clictx, path, "Unapproved");
+}
+
+if (rc < 0) {
+ fprintf(stderr, "gcli: error: failed to unapprove pull request: %s\n",
+         gcli_get_error(g_clictx));
+ if (strstr(gcli_get_error(g_clictx), "reject your own pull is not allowed"))
+  fprintf(stderr, "NOTE: Gitea does not allow you to unapprove your own pull requests.\n");
+ return GCLI_EX_DATAERR;
+}
+
+free(message);
+
+return GCLI_EX_OK;
 }
 
 struct gcli_cmd_actions gcli_pull_actions = {

--- a/src/curl.c
+++ b/src/curl.c
@@ -428,6 +428,11 @@ gcli_fetch_with_method(
 	}
 
 	ret = curl_easy_perform(ctx->curl);
+	if (gcli_be_verbose(ctx)) {
+		fprintf(stderr, "info: cURL response body:\n");
+		fwrite(buf->data, 1, buf->length, stderr);
+		fprintf(stderr, "\n");
+	}
 	rc = gcli_curl_check_api_error(ctx, ret, url, buf);
 
 	if (ctx->report_progress)

--- a/src/forges.c
+++ b/src/forges.c
@@ -342,6 +342,7 @@ gitea_forge_descriptor =
 	.pull_set_milestone        = gitea_pull_set_milestone,
 	.pull_set_title            = gitea_pull_set_title,
 	.pull_get_reviews          = gitea_pull_get_reviews,
+	.pull_create_review        = gitea_pull_create_review,
 
 	/* Releases */
 	.create_release            = gitea_create_release,

--- a/src/gitea/pulls.c
+++ b/src/gitea/pulls.c
@@ -30,6 +30,7 @@
 #include <gcli/gitea/pulls.h>
 #include <gcli/gitea/repos.h>
 #include <gcli/gitea/issues.h>
+#include <gcli/gitea/review.h>
 #include <gcli/github/issues.h>
 #include <gcli/github/pulls.h>
 
@@ -325,4 +326,12 @@ gitea_pull_get_reviews(struct gcli_ctx *ctx,
                        struct gcli_pull_reviews *out)
 {
 	return github_pull_get_reviews(ctx, path, out);
+}
+
+
+int
+gitea_pull_get_review_url(struct gcli_ctx *ctx, struct gcli_path const *const path,
+                          char **url)
+{
+    return gitea_pull_make_url(ctx, path, url, "/reviews");
 }

--- a/src/gitea/review.c
+++ b/src/gitea/review.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2025 Nico Sonack <nsonack@herrhotzenplotz.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gcli/gitea/review.h>
+#include <gcli/gitea/pulls.h>
+#include <gcli/json_gen.h>
+#include <gcli/port/err.h>
+#include <gcli/port/string.h>
+#include <gcli/json_util.h>
+
+#include <templates/github/pulls.h>
+
+int
+gitea_pull_create_review(struct gcli_ctx *ctx,
+                         struct gcli_pull_create_review_details const *details)
+{
+    char *url = NULL, *payload = NULL;
+    struct gcli_jsongen gen = {0};
+    char const *const state_string[] = {
+        [GCLI_REVIEW_ACCEPT_CHANGES] = "APPROVED",
+        [GCLI_REVIEW_REQUEST_CHANGES] = "REQUEST_CHANGES",
+        [GCLI_REVIEW_COMMENT] = "COMMENT",
+    };
+    int rc = 0;
+
+    rc = gitea_pull_get_review_url(ctx, &details->path, &url);
+    if (rc < 0)
+    	return rc;
+
+    // For Gitea, we can directly submit the review in one step.
+    // The initial POST to the reviews endpoint creates and submits the review.
+    // Therefore, we don't need the separate "submit" step.
+    gcli_jsongen_init(&gen);
+    gcli_jsongen_begin_object(&gen);
+    {
+        if (details->body) {
+            gcli_jsongen_objmember(&gen, "body");
+            gcli_jsongen_string(&gen, details->body);
+        }
+
+
+        gcli_jsongen_objmember(&gen, "event");
+        gcli_jsongen_string(&gen, state_string[details->review_state]);
+    }
+    gcli_jsongen_end_object(&gen);
+
+    payload = gcli_jsongen_to_string(&gen);
+    gcli_jsongen_free(&gen);
+// Directly submit the review. Gitea's API creates and submits in one step.
+rc = gcli_fetch_with_method(ctx, "POST", url, payload, NULL, NULL);
+
+gcli_clear_ptr(&url);
+gcli_clear_ptr(&payload);
+
+
+    return rc;
+}

--- a/src/port/util.c
+++ b/src/port/util.c
@@ -110,3 +110,57 @@ err_seek:
 
 	return rc;
 }
+int
+gcli_read_stream(FILE *stream, char **buffer)
+{
+	size_t size = 0;
+	size_t capacity = 1024;
+	char *buf = malloc(capacity);
+	if (!buf)
+		return -1;
+
+	while (!feof(stream)) {
+		size_t const n = fread(buf + size, 1, capacity - size, stream);
+		size += n;
+
+		if (size == capacity) {
+			capacity *= 2;
+			char *new_buf = realloc(buf, capacity);
+			if (!new_buf) {
+				free(buf);
+				return -1;
+			}
+			buf = new_buf;
+		}
+	}
+
+	// Process backslash escapes
+	size_t j = 0;
+	for (size_t i = 0; i < size; i++) {
+		if (buf[i] == '\\' && i + 1 < size) {
+			switch (buf[i+1]) {
+			case 'n':
+				buf[j++] = '\n';
+				i++;
+				break;
+			case 'r':
+				buf[j++] = '\r';
+				i++;
+				break;
+			case '\\':
+				buf[j++] = '\\';
+				i++;
+				break;
+			default:
+				buf[j++] = buf[i];
+			}
+		} else {
+			buf[j++] = buf[i];
+		}
+	}
+	size = j;
+
+	buf[size] = '\0';
+	*buffer = buf;
+	return size;
+}

--- a/src/pulls.c
+++ b/src/pulls.c
@@ -342,11 +342,11 @@ int
 gcli_pull_approve(struct gcli_ctx *ctx, struct gcli_path const *const path,
                   char const *const message)
 {
-	struct gcli_pull_create_review_details details = {0};
-
-	details.path = *path;
-	details.body = message;
-	details.review_state = GCLI_PULL_APPROVED;
+	struct gcli_pull_create_review_details details = {
+		.path = *path,
+		.body = message ? message : "Approved",
+		.review_state = GCLI_PULL_APPROVED,
+	};
 
 	return gcli_pull_create_review(ctx, &details);
 }
@@ -355,11 +355,11 @@ int
 gcli_pull_unapprove(struct gcli_ctx *ctx, struct gcli_path const *const path,
                     char const *const message)
 {
-	struct gcli_pull_create_review_details details = {0};
-
-	details.path = *path;
-	details.body = message;
-	details.review_state = GCLI_PULL_UNAPPROVED;
+	struct gcli_pull_create_review_details details = {
+		.path = *path,
+		.body = message ? message : "Unapproved",
+		.review_state = GCLI_PULL_UNAPPROVED,
+	};
 
 	return gcli_pull_create_review(ctx, &details);
 }


### PR DESCRIPTION
- Introduces dedicated Gitea review module for pull request approval and unapproval.
- Adapts Gitea API interaction for reviews to a single-step POST, resolving previous issues with two-step submission.
- Enables gcli pr approve and gcli pr unapprove commands for Gitea users.
- Ensures backward compatibility and no regressions for existing GitHub and GitLab functionalities.
- Adds verbose cURL response body logging for improved debugging capabilities.
- Implement -F / --file additional parameter to pass messages in non-interactive mode
- Enhance -F / --file by allowing stream stdin input thanks to '-' convention