### PR TITLE
Fixed: double free after create_issue

### DIFF
--- a/src/cmd/issues.c
+++ b/src/cmd/issues.c
@@ -276,7 +276,6 @@ create_issue(struct gcli_submit_issue_options *opts, bool always_yes)
 	rc = gcli_issue_submit(g_clictx, opts);
 
 	free(opts->body);
-	free(opts->body);
 
 	return rc;
 }


### PR DESCRIPTION
Backtrace:

```
Core was generated by `gcli -t github issues create -o altlinuxtest -r hello Bug: Create Issue'.
Program terminated with signal SIGABRT, Aborted.
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
44	      return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;

Thread 1 (Thread 0x7fc7f7c95a40 (LWP 1866)):
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007fc7f8a9c0ef in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:78
#2  0x00007fc7f8a47e82 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fc7f8a304f2 in __GI_abort () at abort.c:79
#4  0x00007fc7f8a31335 in __libc_message_impl (fmt=fmt@entry=0x7fc7f8bb5314 "%s\n") at ../sysdeps/posix/libc_fatal.c:134
#5  0x00007fc7f8aa5d27 in malloc_printerr (str=str@entry=0x7fc7f8bb8710 "double free or corruption (fasttop)") at malloc.c:5772
#6  0x00007fc7f8aa7f9a in _int_free (av=0x7fc7f8bf1ac0 <main_arena>, p=<optimized out>, have_lock=0) at malloc.c:4607
#7  0x00007fc7f8aaa83f in __GI___libc_free (mem=<optimized out>) at malloc.c:3398
#8  0x000055ca0d1bc24a in create_issue (opts=0x7ffcf945f430, always_yes=0) at src/cmd/issues.c:270
#9  0x000055ca0d1bc6f9 in subcommand_issue_create (argc=1, argv=0x7ffcf945f890) at src/cmd/issues.c:388
#10 0x000055ca0d1bc84b in subcommand_issues (argc=6, argv=0x7ffcf945f868) at src/cmd/issues.c:413
#11 0x000055ca0d1b7ebf in main (argc=7, argv=0x7ffcf945f860) at src/cmd/gcli.c:386
```