### PR TITLE
waitproc: fix waitpid() invocation

### DIFF
--- a/src/waitproc.c
+++ b/src/waitproc.c
@@ -38,7 +38,7 @@ gcli_wait_proc_ok(struct gcli_ctx *ctx, pid_t pid)
 {
 	int status;
 
-	if (waitpid(pid, &status, WEXITED) == -1) {
+	if (waitpid(pid, &status, 0) == -1) {
 		return gcli_error(ctx, "failed to wait for child process: %s",
 		                  strerror(errno));
 	}


### PR DESCRIPTION
`WEXITED` is a flag of `waitid()`.  At least on Linux passing the flag to `waitpid()` results in an immediate return with `EINVAL` error while the child process keeps running in background.

***

This is a follow up on my note in #148:

> ... (then I get `gcli: error: failed to checkout pull: failed to wait for child process: Invalid argument`, but that's some other issue).

The issue is affecting `gcli pulls -i 1074 checkout` and opening URLs (as in `gcli issues -i 763 open`).